### PR TITLE
Avoid logging an error for visual positioning missing library.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,22 @@ request. It's not mandatory at all, but feel free to open an issue to present yo
 
 To start working on the Genymotion device web player, all you need if an HTML page to instanciate a player from your
 local copy of this repository.
+Build the player in dev mode: 
 
-#### Running the tests
+```sh
+yarn build:dev
+```
+
+And import your local file directly
+
+```html
+<link rel="stylesheet" href="file:///[...]/genymotion-device-web-player/dist/css/gm-player.min.css">
+<script src="file:///[...]/genymotion-device-web-player/dist/js/gm-player.min.js"></script>
+```
+
+Don't forget to re-run the build command each time you make a modification to the code.
+
+#### Running tests
 
 ```sh
 # run tests

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Use `GenymotionManager` to instanciate one or more Genymotion device player.
 All you need is an HTML element to use as a container. See example below. 
 
 ```html
+
+<!-- OPTIONAL: Import google maps library with your API key to enable map positioning feature
+<script src="https://maps.googleapis.com/maps/api/js?key=xxxxxxxxxxxxxxxxxxxxxxxx-yyyyyyyyyyyyyy"></script>
+-->
+
 <div id="genymotion"></div>
 
 <script>
@@ -315,7 +320,14 @@ Enables or disables the battery widget. This widget can be used to set the batte
 - **Default:** `true`
 - **Compatibility:** `PaaS`, `SaaS`
 - **Details:**
-Enables or disables the gps widget. This widget can be used to set the gps location of the Android virtual device.
+Enables or disables the gps widget. This widget can be used to set the gps location of the Android virtual device. 
+If you want to use a visual map instead of GPS coordinates number to set the location, you must import google maps 
+library with your API key. 
+
+```html
+<!-- OPTIONAL: Import google maps library with your API key to enable map positioning feature -->
+<script src="https://maps.googleapis.com/maps/api/js?key=xxxxxxxxxxxxxxxxxxxxxxxx-yyyyyyyyyyyyyy"></script>
+```
 
 ### `gpsSpeedSupport`
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint src tests gulp",
     "checkstyle": "eslint -f checkstyle -o ./tests/reports/lint/report.xml src tests gulp",
     "validate": "yarn lint; yarn checkstyle",
+    "build:dev": "gulp build",
     "build": "gulp build --production"
   },
   "repository": {

--- a/src/plugins/GPS.js
+++ b/src/plugins/GPS.js
@@ -40,7 +40,6 @@ module.exports = class GPS extends OverlayPlugin {
         if (typeof google !== 'undefined') {
             this.elevationService = new google.maps.ElevationService();
         } else {
-            log.error('Cant find Google Maps API object, did you forget to embed it?');
             this.elevationService = false;
         }
         this.markers = [];
@@ -260,6 +259,10 @@ module.exports = class GPS extends OverlayPlugin {
         map.className = 'map';
         map.innerHTML = this.i18n.GPS_MAP || 'MAP';
         map.onclick = this.onOpenMapButtonClicked.bind(this);
+
+        if (!this.elevationService) {
+            map.disabled = true;
+        }
 
         this.rightGeolocWrap.className = 'gm-geoloc-wrap';
         this.geolocBtn.className = 'gm-gps-geoloc';

--- a/tests/unit/gps.test.js
+++ b/tests/unit/gps.test.js
@@ -53,6 +53,20 @@ describe('GPS Plugin', () => {
             expect(document.getElementsByClassName('gm-gps-speed')).toHaveLength(0);
         });
 
+        test('has an active map button when gmaps lib is setup', () => {
+            window.google = {maps:{ElevationService:jest.fn()}};
+            instance = new Instance();
+            gps = new GPS(instance, {});
+            expect(document.getElementsByClassName('map')[0].disabled).toBeFalsy();
+        });
+
+        test('has a disable map button when gmaps lib not imported', () => {
+            window.google = undefined; // eslint-disable-line no-undefined
+            instance = new Instance();
+            gps = new GPS(instance, {});
+            expect(document.getElementsByClassName('map')[0].disabled).toBeTruthy();
+        });
+
         test('is initialized properly at construct', () => {
             // Widget views
             expect(document.getElementsByClassName('gm-gps-controls')).toHaveLength(1);


### PR DESCRIPTION
## Description

When using the GPS widget, an error pops up in the console is google maps library is missing

**Console error:** 
![2021-11-08-112509_705x74_scrot](https://user-images.githubusercontent.com/2337482/140726400-ea9db6ad-b09f-4077-a72f-47e39f41e717.png)

**Adapted UI (maps button disabled)** 
![2021-11-08-112419_502x465_scrot](https://user-images.githubusercontent.com/2337482/140726396-2fb2afde-f410-4f26-ab07-4610beeafeb5.png)


Things done: 
- Document the requirement
- Remove error logging, make the UI detect if the requirement is met
- Update contribution documentation

Fixes #<issue>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
