### PR TITLE
Disable fileupload to avoid missing configuration error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const GenymotionManager = require('genymotion/device-web-player');
 
 ```html
 <style lang="scss">
-    @import "genymotion-device-web-player/dist/css/Genymotion";
+    @import "genymotion-device-web-player/dist/css/gm-player.min.css";
 </style>
 ```
 
@@ -73,6 +73,8 @@ const GenymotionManager = require('genymotion/device-web-player');
 
 Use `GenymotionManager` to instanciate one or more Genymotion device player.
 All you need is an HTML element to use as a container. See example below. 
+To find your instance WebRTC address, use the [SaaS API](https://developer.genymotion.com/saas/#operation/getInstance)
+or check the [PaaS documentation](https://docs.genymotion.com/paas/latest/02_Getting_Started/), based on your device provider.
 
 ```html
 
@@ -83,14 +85,15 @@ All you need is an HTML element to use as a container. See example below.
 <div id="genymotion"></div>
 
 <script>
+    // Instance address
+    const webrtcAddress = 'wss://x.x.x.x';
+    
     // See "Features & options" section for more details about options
     const options = {
         template: "player",    // template defines how player is displayed
-        token: 'i-XXXXXXXXXX'  // token is the shared secret to connect to your VM
+        token: 'i-XXXXXXXXXX', // token is the shared secret to connect to your VM
+        fileUpload: false      // requires fileUploadUrl
     };
-    
-    // The URL addresses of your instances
-    const webrtcAddress = 'wss://x.x.x.x';
 
     // Device player instanciation
     const genymotion = new GenymotionManager();


### PR DESCRIPTION
## Description

Disable `fileUpload` widget in readme exemple to avoid missing `fileUploadUrl` configuration error.
As already documented, the `fileUpload` option (enabled by default) requires another option to be set: `fileUploadUrl`. Otherwise, this happens: 

![2021-11-08-122401_909x94_scrot](https://user-images.githubusercontent.com/2337482/140734183-ac33b919-6e6e-4123-962f-0005b89a2cfc.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
