### PR TITLE
Fix missing "container" variable declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ or check the [PaaS documentation](https://docs.genymotion.com/paas/02_Getting_St
 <script>
     // Instance address
     const webrtcAddress = 'wss://x.x.x.x';
+    const container = document.getElementById('genymotion');
     
     // See "Features & options" section for more details about options
     const options = {


### PR DESCRIPTION
## Description

The code sample was incomplete because of the variable "container" not being defined. This commit add the missing declaration and fixes the issue.

| Before  | After |
| :-------: |:------:|
| ![image](https://user-images.githubusercontent.com/1827605/188891915-de4b43c9-5f30-4e00-8e80-0d509647d9f1.png)  | ![image](https://user-images.githubusercontent.com/1827605/188891947-9adc76f3-9914-4a93-9acf-f65b047a5503.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
