### PR TITLE
Fix yarn gulp serve command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -180,14 +180,10 @@ gulp.task('build', gulp.series(
 ));
 
 // Watch project update
-gulp.task('watch', gulp.series('build', function() {
+gulp.task('watch', gulp.series('build', function(cb) {
     gulp.watch([
         PATHS.SRC.ASSETS.STYLES + '/**/*.scss'
     ], gulp.series('app-styles'));
-
-    gulp.watch([
-        PATHS.TEST.UT + '/**/*.js'
-    ], gulp.series('test'));
 
     gulp.watch([
         PATHS.SRC.BASE + '/*.js',
@@ -196,6 +192,8 @@ gulp.task('watch', gulp.series('build', function() {
         PATHS.SRC.WORKER + '/**/*.js',
         PATHS.SRC.TEMPLATES + '/**/*'
     ], gulp.series('app-js'));
+
+    cb();
 }));
 
 // Serve project
@@ -206,7 +204,5 @@ gulp.task('serve', gulp.series('watch', function(cb) {
             baseDir: PATHS.DEST.BASE
         },
         port: 8000
-    });
-
-    cb();
+    }, cb);
 }));


### PR DESCRIPTION
- Remove tests files watcher as 'test' task does not exist.
- Add missing cb() call to 'watch' so it can complete correctly.
- No need to call cb() directly in 'serve', pass it to bowserSync.init()

## Description

Fixes gulpfile.js to make 'yarn gulp serve' work again. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
