### PR TITLE
Fix network widget elements duplicated

### DIFF
--- a/src/plugins/Network.js
+++ b/src/plugins/Network.js
@@ -37,6 +37,14 @@ module.exports = class Network extends OverlayPlugin {
         this.renderToolbarButton();
         this.renderWidget();
 
+        /*
+         * Redis message for enabling/disabling mobile throttling and 5G support
+         * could be sent without rendering the widget from srach
+         * to avoid recreation of widget elements, check this parameters before.
+         */
+        this.mobileThrottlingManaged = false;
+        this.network5Gmanaged = false;
+
         this.wifiInputChecked = true;
         this.mobileInputChecked = true;
 
@@ -60,6 +68,10 @@ module.exports = class Network extends OverlayPlugin {
     }
 
     enableMobileThrottling() {
+        if (this.mobileThrottlingManaged) {
+            return;
+        }
+
         this.mobilethrottling = true;
         // Add wifi checkbox
         const wifiGroup = document.createElement('div');
@@ -133,9 +145,15 @@ module.exports = class Network extends OverlayPlugin {
             });
 
         this.updateMobileSectionStatus();
+
+        this.mobileThrottlingManaged = true;
     }
 
     disableMobileThrottling() {
+        if (this.mobileThrottlingManaged) {
+            return;
+        }
+
         this.mobilethrottling = false;
 
         // Generate input rows for network profiles
@@ -151,16 +169,28 @@ module.exports = class Network extends OverlayPlugin {
                 this.selectProfile.add(option);
             });
         this.profileInputs.appendChild(this.selectProfile);
+
+        this.mobileThrottlingManaged = true;
     }
 
     enable5G() {
+        if (this.network5Gmanaged) {
+            return;
+        }
+
         const profile = MOBILE_PROFILES.at(0);
         const option = new Option(profile.label, profile.name);
         this.selectMobileProfile.add(option);
+
+        this.network5Gmanaged = true;
     }
 
     disable5G() {
-        // Nothing to do!
+        if (this.network5Gmanaged) {
+            return;
+        }
+
+        this.network5Gmanaged = true;
     }
 
     // Handle settings event to enable/disable wifi|mobile data

--- a/src/plugins/Network.js
+++ b/src/plugins/Network.js
@@ -42,8 +42,8 @@ module.exports = class Network extends OverlayPlugin {
          * could be sent without rendering the widget from srach
          * to avoid recreation of widget elements, check this parameters before.
          */
-        this.mobileThrottlingManaged = false;
-        this.network5Gmanaged = false;
+        this.mobileThrottlingConfigured = false;
+        this.network5GConfigured = false;
 
         this.wifiInputChecked = true;
         this.mobileInputChecked = true;
@@ -68,7 +68,7 @@ module.exports = class Network extends OverlayPlugin {
     }
 
     enableMobileThrottling() {
-        if (this.mobileThrottlingManaged) {
+        if (this.mobileThrottlingConfigured) {
             return;
         }
 
@@ -146,11 +146,11 @@ module.exports = class Network extends OverlayPlugin {
 
         this.updateMobileSectionStatus();
 
-        this.mobileThrottlingManaged = true;
+        this.mobileThrottlingConfigured = true;
     }
 
     disableMobileThrottling() {
-        if (this.mobileThrottlingManaged) {
+        if (this.mobileThrottlingConfigured) {
             return;
         }
 
@@ -170,11 +170,11 @@ module.exports = class Network extends OverlayPlugin {
             });
         this.profileInputs.appendChild(this.selectProfile);
 
-        this.mobileThrottlingManaged = true;
+        this.mobileThrottlingConfigured = true;
     }
 
     enable5G() {
-        if (this.network5Gmanaged) {
+        if (this.network5GConfigured) {
             return;
         }
 
@@ -182,15 +182,15 @@ module.exports = class Network extends OverlayPlugin {
         const option = new Option(profile.label, profile.name);
         this.selectMobileProfile.add(option);
 
-        this.network5Gmanaged = true;
+        this.network5GConfigured = true;
     }
 
     disable5G() {
-        if (this.network5Gmanaged) {
+        if (this.network5GConfigured) {
             return;
         }
 
-        this.network5Gmanaged = true;
+        this.network5GConfigured = true;
     }
 
     // Handle settings event to enable/disable wifi|mobile data

--- a/src/plugins/Network.js
+++ b/src/plugins/Network.js
@@ -39,8 +39,8 @@ module.exports = class Network extends OverlayPlugin {
 
         /*
          * Redis message for enabling/disabling mobile throttling and 5G support
-         * could be sent without rendering the widget from srach
-         * to avoid recreation of widget elements, check this parameters before.
+         * could be sent without rendering the widget from scratch
+         * to avoid recreation of widget elements, check these parameters before.
          */
         this.mobileThrottlingConfigured = false;
         this.network5GConfigured = false;


### PR DESCRIPTION
This is due to the fact redis messages are received after reboot while the widget is already created and did not rendered from scratch To avoid such behaviour we add 2 boolean variable to check if the mobile throttling ans 5G enabling/disabling operation was already done or not.

## Description

Please include a summary of the change and which issue is fixed if any. Please also include relevant motivation and context (a screenshot is appreciated).

Fixes #<issue>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
