### PR TITLE
Rework copy/paste widget

### DIFF
--- a/src/plugins/Clipboard.js
+++ b/src/plugins/Clipboard.js
@@ -83,21 +83,14 @@ module.exports = class Clipboard extends OverlayPlugin {
         // Generate title
         const title = document.createElement('div');
         title.className = 'gm-title';
-        title.innerHTML = this.i18n.CLIPBOARD_TITLE || 'Clipboard';
+        title.innerHTML = this.i18n.CLIPBOARD_TITLE || 'Device Clipboard';
         this.container.appendChild(title);
 
         this.clipboardInput = document.createElement('textarea');
         this.clipboardInput.className = 'gm-clipboard-input';
 
-        this.copiedText = document.createElement('div');
-        this.copiedText.innerHTML = this.i18n.CLIPBOARD_COPIED || 'Copied to local clipboard';
-        this.copiedText.classList.add('gm-text-copied');
-        this.copiedText.classList.add('gm-invisible');
-        this.copiedText.classList.add('gm-hidden');
-
         // Setup
         this.container.appendChild(this.clipboardInput);
-        this.container.appendChild(this.copiedText);
         this.widget.className = 'gm-overlay gm-clipboard-plugin gm-hidden';
 
         // Add close button
@@ -127,9 +120,6 @@ module.exports = class Clipboard extends OverlayPlugin {
             this.instance.emit('close-overlays');
             this.instance.emit('keyboard-disable');
             this.clipboardInput.value = this.clipboard;
-            if (this.clipboard !== '') {
-                setTimeout(this.copyInstanceClipboardToClient, 100, this.clipboardInput, this.copiedText);
-            }
         } else {
             this.instance.emit('keyboard-enable');
             this.widget.onclose();

--- a/tests/unit/clipboard.test.js
+++ b/tests/unit/clipboard.test.js
@@ -27,7 +27,6 @@ describe('Clipboard Plugin', () => {
             instance = new Instance();
             clipboard = new Clipboard(instance, {
                 CLIPBOARD_TITLE: 'TEST CLIPBOARD PLUGIN TITLE',
-                CLIPBOARD_COPIED: 'TEST CLIPBOARD COPIED TO CLIPBOARD'
             });
             plugin = document.getElementsByClassName('gm-clipboard-plugin')[0];
         });
@@ -45,7 +44,6 @@ describe('Clipboard Plugin', () => {
 
         test('has translations', () => {
             expect(plugin.innerHTML).toEqual(expect.stringContaining('TEST CLIPBOARD PLUGIN TITLE'));
-            expect(plugin.innerHTML).toEqual(expect.stringContaining('TEST CLIPBOARD COPIED TO CLIPBOARD'));
         });
 
         test('reflects internal clipboard state when displayed', () => {


### PR DESCRIPTION
## Description

Let's simplify the copy/paste widget and avoid non solicited Host clipboard modification.
This will just represent the device clipboard and user will just copy/paste onto it or modify it freely.
We might rework the widget later, but this will help users understand its mechanism.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
