### PR TITLE
Allow gamepads even if no mapping is found

### DIFF
--- a/src/plugins/GamepadManager.js
+++ b/src/plugins/GamepadManager.js
@@ -266,7 +266,6 @@ module.exports = class GamepadManager {
         const customEvent = new CustomEvent('gm-gamepadConnected', {detail: parsedGamepad});
         if (event.gamepad.mapping === '') {
             log.error(`Unsupported gamepad mapping for gamepad ${parsedGamepad.name}`);
-            return;
         }
         window.dispatchEvent(customEvent);
     }


### PR DESCRIPTION
## Description

This change was preventing all gamepads to work on Linux. For now we'll allow gamepads even if there is no recognised mapping, and simply log the error. I have no idea how we can detect gamepads for which the mapping is truly broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
