### PR TITLE
Fix unmute popup

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -564,7 +564,7 @@ module.exports = class DeviceRenderer {
                     this.dispatchEvent('video', {msg: 'play automatically allowed without sound'});
                     const popup = document.createElement('div');
                     popup.classList.add('gm-click-to-unmute');
-                    popup.innerHTML = 'By default, the sound has been turned off, '
+                    popup.innerHTML = this.options.i18n.UNMUTE_INVITE || 'By default, the sound has been turned off, '
                         + 'please click anywhere to re-enable audio';
                     this.videoWrapper.prepend(popup);
                     const addSound = () => {

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -569,14 +569,14 @@ module.exports = class DeviceRenderer {
                     this.videoWrapper.prepend(popup);
                     const addSound = () => {
                         this.video.muted = false;
-                        this.video.removeEventListener('click', addSound);
-                        this.video.removeEventListener('touchend', addSound);
+                        window.removeEventListener('click', addSound);
+                        window.removeEventListener('touchend', addSound);
                         this.dispatchEvent('video', {msg: 'sound manually allowed by click'});
                         popup.remove();
                         log.debug('Playing video with sound enabled has been authorized due to user click');
                     };
-                    this.video.addEventListener('click', addSound);
-                    this.video.addEventListener('touchend', addSound);
+                    window.addEventListener('click', addSound, {once:true});
+                    window.addEventListener('touchend', addSound, {once:true});
                 }).catch(() => {
                     log.debug('Can\'t play video, even with sound disabled');
                     this.dispatchEvent('video', {msg: 'play denied even without sound'});


### PR DESCRIPTION
## Description

Update unmute popup:
- ~~make it clickable too (since the cursor suggests this anyway)~~ in fact, make the whole window clickable
- add i18n for this popup

This could probably be merged in the main branch too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
