### PR TITLE
Media manager: Add return values in order to fail loudly

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -620,8 +620,9 @@ module.exports = class DeviceRenderer {
              */
             description.sdp = description.sdp.replace(
                 new RegExp(`(a=fmtp:${m[1]}) ?(.*)(\r?\n)`, 'g'),
+                // eslint-disable-next-line no-unused-vars
                 (match, fmtpId, existingParams, lineEnding, offset, string) => {
-                    const modified = existingParams ? `${fmtpId} ${existingParams};` : `${fmtpId} `
+                    const modified = existingParams ? `${fmtpId} ${existingParams};` : `${fmtpId} `;
                     return `${modified}stereo=1;maxplaybackrate=48000;maxaveragebitrate=256000${lineEnding}`;
                 });
         }

--- a/src/plugins/MediaManager.js
+++ b/src/plugins/MediaManager.js
@@ -68,33 +68,34 @@ module.exports = class MediaManager {
     /**
      * Toggle local video forwarding.
      * Redirect the client webcam video stream to the instance.
+     * @returns {boolean} true on success, false on fail
      */
     toggleVideoStreaming() {
         if (!this.videoStreaming) {
-            this.startVideoStreaming();
-        } else {
-            this.stopVideoStreaming();
+            return this.startVideoStreaming();
         }
+        return this.stopVideoStreaming();
     }
 
     /**
      * Toggle local audio forwarding.
      * Redirect the client microphone audio stream to the instance.
+     * @returns {boolean} true on success, false on fail
      */
     toggleAudioStreaming() {
         if (!this.audioStreaming) {
-            this.startAudioStreaming();
-        } else {
-            this.stopAudioStreaming();
+            return this.startAudioStreaming();
         }
+        return this.stopAudioStreaming();
     }
 
     /**
      * Initialize and start client webcam video stream.
+     * @returns {boolean} true on success, false on fail
      */
     async startVideoStreaming() {
         if (!navigator.mediaDevices) {
-            return;
+            return false;
         }
 
         try {
@@ -108,18 +109,20 @@ module.exports = class MediaManager {
             log.debug('Client video stream ready');
             this.videoStreaming = true;
             this.localVideoStream = mediaStream;
-            this.addVideoStream(mediaStream);
+            return this.addVideoStream(mediaStream);
         } catch (error) {
             this.onVideoStreamError(error);
+            return false;
         }
     }
 
     /**
      * Initialize and start client microphone audio stream.
+     * @returns {boolean} true on success, false on fail
      */
     async startAudioStreaming() {
         if (!navigator.mediaDevices) {
-            return;
+            return false;
         }
 
         try {
@@ -130,9 +133,10 @@ module.exports = class MediaManager {
             log.debug('Client audio stream ready');
             this.audioStreaming = true;
             this.localAudioStream = mediaStream;
-            this.addAudioStream(mediaStream);
+            return this.addAudioStream(mediaStream);
         } catch (error) {
             this.onAudioStreamError(error);
+            return false;
         }
     }
 
@@ -156,28 +160,32 @@ module.exports = class MediaManager {
 
     /**
      * Stop client webcam video stream.
+     * @returns {boolean} true on success, false on fail
      */
     stopVideoStreaming() {
         if (!this.videoStreaming) {
-            return;
+            return false;
         }
         log.debug('removed local video stream');
-        this.removeVideoStream(this.localVideoStream);
+        const result = this.removeVideoStream(this.localVideoStream);
         this.localVideoStream = null;
         this.videoStreaming = false;
+        return result;
     }
 
     /**
      * Stop client microphone audio stream.
+     * @returns {boolean} true on success, false on fail
      */
     stopAudioStreaming() {
         if (!this.audioStreaming) {
-            return;
+            return false;
         }
         log.debug('removed local audio stream');
-        this.removeAudioStream(this.localAudioStream);
+        const result = this.removeAudioStream(this.localAudioStream);
         this.localAudioStream = null;
         this.audioStreaming = false;
+        return result;
     }
 
     /**
@@ -216,11 +224,12 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream
      *
      * @param {MediaStream} stream Audio stream to add.
+     * @returns {boolean} true on success, false on fail
      */
     addAudioStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not add audio stream: connection is not ready');
-            return;
+            return false;
         }
         /**
          * If microphoneSender is defined, this means that we already added
@@ -240,6 +249,7 @@ module.exports = class MediaManager {
             }
         }
         this.instance.renegotiateWebRTCConnection();
+        return true;
     }
 
     /**
@@ -249,11 +259,12 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream
      *
      * @param {MediaStream} stream Video stream to add.
+     * @returns {boolean} true on success, false on fail
      */
     addVideoStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not add video stream: connection is not ready');
-            return;
+            return false;
         }
         /**
          * If cameraSender is defined, this means that we already added
@@ -284,6 +295,7 @@ module.exports = class MediaManager {
             }
         }
         this.instance.renegotiateWebRTCConnection();
+        return true;
     }
 
     /**
@@ -293,11 +305,12 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeStream
      *
      * @param {MediaStream} stream Audio stream to stop and remove.
+     * @returns {boolean} true on success, false on fail
      */
     removeAudioStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not remove audio stream: connection is not ready');
-            return;
+            return false;
         }
         if (stream instanceof MediaStream) {
             stream.getTracks().forEach((track) => {
@@ -308,6 +321,7 @@ module.exports = class MediaManager {
             }
             this.instance.renegotiateWebRTCConnection();
         }
+        return true;
     }
 
     /**
@@ -317,11 +331,12 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeStream
      *
      * @param {MediaStream} stream Video stream to stop and remove.
+     * @returns {boolean} true on success, false on fail
      */
     removeVideoStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not remove video stream: connection is not ready');
-            return;
+            return false;
         }
         if (stream instanceof MediaStream) {
             stream.getTracks().forEach((track) => {
@@ -336,6 +351,7 @@ module.exports = class MediaManager {
             }
             this.instance.renegotiateWebRTCConnection();
         }
+        return true;
     }
 
     /**

--- a/src/plugins/MediaManager.js
+++ b/src/plugins/MediaManager.js
@@ -68,9 +68,9 @@ module.exports = class MediaManager {
     /**
      * Toggle local video forwarding.
      * Redirect the client webcam video stream to the instance.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    toggleVideoStreaming() {
+    async toggleVideoStreaming() {
         if (!this.videoStreaming) {
             return this.startVideoStreaming();
         }
@@ -80,9 +80,9 @@ module.exports = class MediaManager {
     /**
      * Toggle local audio forwarding.
      * Redirect the client microphone audio stream to the instance.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    toggleAudioStreaming() {
+    async toggleAudioStreaming() {
         if (!this.audioStreaming) {
             return this.startAudioStreaming();
         }
@@ -91,7 +91,7 @@ module.exports = class MediaManager {
 
     /**
      * Initialize and start client webcam video stream.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
     async startVideoStreaming() {
         if (!navigator.mediaDevices) {
@@ -118,7 +118,7 @@ module.exports = class MediaManager {
 
     /**
      * Initialize and start client microphone audio stream.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
     async startAudioStreaming() {
         if (!navigator.mediaDevices) {
@@ -160,14 +160,14 @@ module.exports = class MediaManager {
 
     /**
      * Stop client webcam video stream.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    stopVideoStreaming() {
+    async stopVideoStreaming() {
         if (!this.videoStreaming) {
             return false;
         }
         log.debug('removed local video stream');
-        const result = this.removeVideoStream(this.localVideoStream);
+        const result = await this.removeVideoStream(this.localVideoStream);
         this.localVideoStream = null;
         this.videoStreaming = false;
         return result;
@@ -175,14 +175,14 @@ module.exports = class MediaManager {
 
     /**
      * Stop client microphone audio stream.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    stopAudioStreaming() {
+    async stopAudioStreaming() {
         if (!this.audioStreaming) {
             return false;
         }
         log.debug('removed local audio stream');
-        const result = this.removeAudioStream(this.localAudioStream);
+        const result = await this.removeAudioStream(this.localAudioStream);
         this.localAudioStream = null;
         this.audioStreaming = false;
         return result;
@@ -224,9 +224,9 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream
      *
      * @param {MediaStream} stream Audio stream to add.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    addAudioStream(stream) {
+    async addAudioStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not add audio stream: connection is not ready');
             return false;
@@ -248,8 +248,7 @@ module.exports = class MediaManager {
                     stream);
             }
         }
-        this.instance.renegotiateWebRTCConnection();
-        return true;
+        return this.instance.renegotiateWebRTCConnection();
     }
 
     /**
@@ -259,9 +258,9 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream
      *
      * @param {MediaStream} stream Video stream to add.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    addVideoStream(stream) {
+    async addVideoStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not add video stream: connection is not ready');
             return false;
@@ -294,8 +293,7 @@ module.exports = class MediaManager {
                     stream);
             }
         }
-        this.instance.renegotiateWebRTCConnection();
-        return true;
+        return this.instance.renegotiateWebRTCConnection();
     }
 
     /**
@@ -305,9 +303,9 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeStream
      *
      * @param {MediaStream} stream Audio stream to stop and remove.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    removeAudioStream(stream) {
+    async removeAudioStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not remove audio stream: connection is not ready');
             return false;
@@ -319,9 +317,9 @@ module.exports = class MediaManager {
             if (this.microphoneSender) {
                 this.instance.peerConnection.removeTrack(this.microphoneSender);
             }
-            this.instance.renegotiateWebRTCConnection();
+            return this.instance.renegotiateWebRTCConnection();
         }
-        return true;
+        return false;
     }
 
     /**
@@ -331,9 +329,9 @@ module.exports = class MediaManager {
      * and https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/removeStream
      *
      * @param {MediaStream} stream Video stream to stop and remove.
-     * @returns {boolean} true on success, false on fail
+     * @returns {Promise<boolean>} A promise that always resolves, with true on success and false on fail
      */
-    removeVideoStream(stream) {
+    async removeVideoStream(stream) {
         if (!this.instance.peerConnection) {
             log.error('Could not remove video stream: connection is not ready');
             return false;
@@ -349,9 +347,9 @@ module.exports = class MediaManager {
             if (this.microphoneSender && this.videoWithMicrophone) {
                 this.instance.peerConnection.removeTrack(this.microphoneSender);
             }
-            this.instance.renegotiateWebRTCConnection();
+            return this.instance.renegotiateWebRTCConnection();
         }
-        return true;
+        return false;
     }
 
     /**

--- a/tests/unit/camera.test.js
+++ b/tests/unit/camera.test.js
@@ -6,6 +6,7 @@ const MediaManager = require('../../src/plugins/MediaManager');
 const Camera = require('../../src/plugins/Camera');
 const Instance = require('../mocks/DeviceRenderer');
 
+// eslint-disable-next-line no-unused-vars
 let mediaManager;
 let instance;
 


### PR DESCRIPTION
## Description

This PR adds return values to most functions in media manager in order to communicate with users of this class if we failed to initialise video or audio input.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
