### PR TITLE
Improve Device Renderer destruction

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -70,6 +70,10 @@ module.exports = class DeviceRenderer {
         document.addEventListener('click', this.clickHandlerCloseOverlay.bind(this));
     }
 
+    /**
+     * Handler for click event, responsible for closing overlay when clicking outside of it.
+     * @param {PointerEvent} event Event that triggered this handler
+     */
     clickHandlerCloseOverlay(event) {
         if (event.target.closest('.gm-overlay') === null
             && !event.target.classList.contains('gm-icon-button')
@@ -212,7 +216,7 @@ module.exports = class DeviceRenderer {
         this.webRTCWebsocket.onclose = (event) => {
             this.video.style.background = this.videoBackupStyleBackground;
             this.initialized = false;
-            log.debug('Error! Maybe your VM is not available yet? (' + event.code +') ' + event.reason);
+            log.debug('Error! Maybe your VM is not available yet? (' + event.code + ') ' + event.reason);
 
             switch (event.code) {
             case 1000:
@@ -478,8 +482,8 @@ module.exports = class DeviceRenderer {
                         popup.remove();
                         log.debug('Playing video with sound enabled has been authorized due to user click');
                     };
-                    window.addEventListener('click', addSound, {once:true});
-                    window.addEventListener('touchend', addSound, {once:true});
+                    window.addEventListener('click', addSound, {once: true});
+                    window.addEventListener('touchend', addSound, {once: true});
                 }).catch(() => {
                     log.debug('Can\'t play video, even with sound disabled');
                     this.dispatchEvent('video', {msg: 'play denied even without sound'});
@@ -495,8 +499,8 @@ module.exports = class DeviceRenderer {
                         this.dispatchEvent('video', {msg: 'play manually allowed by click'});
                         log.debug('Playing video with sound disabled has been authorized due to user click');
                     };
-                    div.addEventListener('click', allowPlay, {once:true});
-                    div.addEventListener('touchend', allowPlay, {once:true});
+                    div.addEventListener('click', allowPlay, {once: true});
+                    div.addEventListener('touchend', allowPlay, {once: true});
                 });
             });
         };
@@ -547,6 +551,9 @@ module.exports = class DeviceRenderer {
         this.renegotiateWebRTCConnection();
     }
 
+    /**
+     * Handler when the peer connection state changes
+     */
     onConnectionStateChange() {
         log.debug('ConnectionState changed:', this.peerConnection.iceConnectionState);
         if (this.peerConnection.iceConnectionState === 'disconnected') {
@@ -829,6 +836,12 @@ module.exports = class DeviceRenderer {
         }
     }
 
+    /**
+     * Destructor for the device renderer. This won't actually destroy the instance, but simply remove all event bindings
+     * so that things can be garbage-collected.
+     * References to the instance in the caller need to be manually deleted too in order for the instance to be garbage-collected.
+     * This method also calls recursively the destroy methods on the plugins if they exist.
+     */
     destroy() {
         document.removeEventListener('click', this.clickHandlerCloseOverlay.bind(this));
         this.peerConnection?.removeEventListener('connectionstatechange', this.onConnectionStateChange);

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -843,8 +843,10 @@ module.exports = class DeviceRenderer {
      * This method also calls recursively the destroy methods on the plugins if they exist.
      */
     destroy() {
-        document.removeEventListener('click', this.clickHandlerCloseOverlay.bind(this));
+        // remove onConnectionStateChange handler in order to prevent reconnecting after disconnect
         this.peerConnection?.removeEventListener('connectionstatechange', this.onConnectionStateChange);
+        this.disconnect();
+        document.removeEventListener('click', this.clickHandlerCloseOverlay);
         this.mediaManager?.destroy();
         this.gamepadManager?.destroy();
         this.peerConnectionStats?.destroy();

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -67,19 +67,14 @@ module.exports = class DeviceRenderer {
         this.x = 0;
         this.y = 0;
 
-        document.addEventListener('click', this.clickHandlerCloseOverlay.bind(this));
-    }
-
-    /**
-     * Handler for click event, responsible for closing overlay when clicking outside of it.
-     * @param {PointerEvent} event Event that triggered this handler
-     */
-    clickHandlerCloseOverlay(event) {
-        if (event.target.closest('.gm-overlay') === null
-            && !event.target.classList.contains('gm-icon-button')
-            && !event.target.classList.contains('gm-dont-close')) {
-            this.emit('close-overlays');
-        }
+        this.clickHandlerCloseOverlay = (event) => {
+            if (event.target.closest('.gm-overlay') === null
+                && !event.target.classList.contains('gm-icon-button')
+                && !event.target.classList.contains('gm-dont-close')) {
+                this.emit('close-overlays');
+            }
+        };
+        document.addEventListener('click', this.clickHandlerCloseOverlay);
     }
 
     /**
@@ -542,6 +537,12 @@ module.exports = class DeviceRenderer {
             div.innerHTML = message;
         };
 
+        this.onConnectionStateChange = () => {
+            log.debug('ConnectionState changed:', this.peerConnection.iceConnectionState);
+            if (this.peerConnection.iceConnectionState === 'disconnected') {
+                this.onWebRTCReady();
+            }
+        };
         this.peerConnection.addEventListener('connectionstatechange', this.onConnectionStateChange);
 
         this.peerConnection.onnegotiationneeded = () => {
@@ -549,16 +550,6 @@ module.exports = class DeviceRenderer {
         };
 
         this.renegotiateWebRTCConnection();
-    }
-
-    /**
-     * Handler when the peer connection state changes
-     */
-    onConnectionStateChange() {
-        log.debug('ConnectionState changed:', this.peerConnection.iceConnectionState);
-        if (this.peerConnection.iceConnectionState === 'disconnected') {
-            this.onWebRTCReady();
-        }
     }
 
     /**

--- a/src/plugins/GamepadManager.js
+++ b/src/plugins/GamepadManager.js
@@ -249,11 +249,26 @@ module.exports = class GamepadManager {
     }
 
     /**
+     * Plugin destructor, responsible for removing all of its callbacks and bindings
+     */
+    destroy() {
+        this.removeGamepadCallbacks();
+    }
+
+    /**
      * Add the listeners for gamepad connect & disconnect
      */
     addGamepadCallbacks() {
         window.addEventListener('gamepadconnected', this.onGamepadConnected.bind(this));
         window.addEventListener('gamepaddisconnected', this.onGamepadDisonnected.bind(this));
+    }
+
+    /**
+     * Remove the listeners for gamepad connect & disconnect
+     */
+    removeGamepadCallbacks() {
+        window.removeEventListener('gamepadconnected', this.onGamepadConnected.bind(this));
+        window.removeEventListener('gamepaddisconnected', this.onGamepadDisonnected.bind(this));
     }
 
     /**

--- a/src/plugins/KeyboardEvents.js
+++ b/src/plugins/KeyboardEvents.js
@@ -69,9 +69,6 @@ module.exports = class KeyboardEvents {
         this.instance.registerEventCallback('keyboard-enable', () => {
             this.transmitKeys = true;
         });
-
-        // This avoid having continuously pressed keys because of alt+tab or any other command that blur from tab
-        window.addEventListener('blur', this.cancelAllPressedKeys.bind(this));
     }
 
     /**
@@ -225,6 +222,9 @@ module.exports = class KeyboardEvents {
         this.instance.root.tabIndex = 0;
 
         if (!this.isListenerAdded) {
+            // This avoid having continuously pressed keys because of alt+tab or any other command that blur from tab
+            window.addEventListener('blur', this.cancelAllPressedKeys.bind(this));
+
             if (!this.keyboardCallbacks) {
                 this.keyboardCallbacks = new Map([
                     ['keypress', this.onKeyPress.bind(this)],
@@ -247,6 +247,7 @@ module.exports = class KeyboardEvents {
         if (!this.keyboardCallbacks || !this.isListenerAdded) {
             return;
         }
+        window.removeEventListener('blur', this.cancelAllPressedKeys.bind(this));
         this.keyboardCallbacks.forEach((value, key) => {
             window.removeEventListener(key, value);
         });

--- a/src/plugins/MediaManager.js
+++ b/src/plugins/MediaManager.js
@@ -46,6 +46,7 @@ module.exports = class MediaManager {
             try {
                 const permissionObj = await navigator.permissions.query({name: 'microphone'});
                 log.debug(`microphone ${permissionObj.state}`);
+                this.microphonePermissionObject = permissionObj;
                 permissionObj.addEventListener('change', this.onMicrophonePermissionChange.bind(this));
             } catch (error) {
                 log.warn('Can\'t get microphone permission object', error);
@@ -56,6 +57,7 @@ module.exports = class MediaManager {
         try {
             const permissionObj = await navigator.permissions.query({name: 'camera'});
             log.debug(`camera ${permissionObj.state}`);
+            this.cameraPermissionObject = permissionObj;
             permissionObj.addEventListener('change', this.onCameraPermissionChange.bind(this));
         } catch (error) {
             log.warn('Can\'t get camera permission object', error);
@@ -370,5 +372,10 @@ module.exports = class MediaManager {
         }
         this.cameraSender = null;
         this.microphoneSender = null;
+    }
+
+    destroy() {
+        this.microphonePermissionObject?.removeEventListener('change', this.onMicrophonePermissionChange.bind(this));
+        this.cameraPermissionObject?.removeEventListener('change', this.onCameraPermissionChange.bind(this));
     }
 };

--- a/src/plugins/MediaManager.js
+++ b/src/plugins/MediaManager.js
@@ -374,6 +374,9 @@ module.exports = class MediaManager {
         this.microphoneSender = null;
     }
 
+    /**
+     * Plugin destructor, responsible for removing all callbacks & bindings so that things are garbage-collected
+     */
     destroy() {
         this.microphonePermissionObject?.removeEventListener('change', this.onMicrophonePermissionChange.bind(this));
         this.cameraPermissionObject?.removeEventListener('change', this.onCameraPermissionChange.bind(this));

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -22,6 +22,10 @@ module.exports = class MouseEvents {
         this.boundEventListener = this.releaseAtPreviousPositionEvent.bind(this);
     }
 
+    destroy() {
+        this.removeMouseCallbacks();
+    }
+
     /**
      * Mouse press event handler.
      *
@@ -159,6 +163,18 @@ module.exports = class MouseEvents {
         this.instance.videoWrapper.addEventListener('mousemove', this.onMouseMoveEvent.bind(this), false);
         this.instance.videoWrapper.addEventListener('wheel', this.onMouseWheelEvent.bind(this), {passive: false});
         this.instance.videoWrapper.addEventListener('contextmenu', this.cancelContextMenu.bind(this), false);
+    }
+
+    /**
+     * Remove all events handlers
+     */
+    removeMouseCallbacks() {
+        this.instance.videoWrapper.removeEventListener('mousedown', this.onMousePressEvent.bind(this), false);
+        this.instance.videoWrapper.removeEventListener('mouseup', this.onMouseReleaseEvent.bind(this), false);
+        this.instance.videoWrapper.removeEventListener('mousemove', this.onMouseMoveEvent.bind(this), false);
+        this.instance.videoWrapper.removeEventListener('wheel', this.onMouseWheelEvent.bind(this), {passive: false});
+        this.instance.videoWrapper.removeEventListener('contextmenu', this.cancelContextMenu.bind(this), false);
+        document.removeEventListener('mouseup', this.boundEventListener, false);
     }
 
     getWheelDeltaPixels(delta, mode) {

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -22,6 +22,9 @@ module.exports = class MouseEvents {
         this.boundEventListener = this.releaseAtPreviousPositionEvent.bind(this);
     }
 
+    /**
+     * Plugin destructor, responsible for removing all callbacks & bindings so that things are garbage-collected
+     */
     destroy() {
         this.removeMouseCallbacks();
     }

--- a/src/plugins/PeerConnectionStats.js
+++ b/src/plugins/PeerConnectionStats.js
@@ -21,7 +21,7 @@ module.exports = class PeerConnectionStats {
 
         this.connection = connection;
 
-        setTimeout(() => {
+        this.timeoutID = setTimeout(() => {
             this.connection.getStats(null).then((stats) => {
                 stats.forEach((entry) => {
                     if (entry.kind === 'video') {
@@ -106,5 +106,11 @@ module.exports = class PeerConnectionStats {
         if (element) {
             element.remove();
         }
+    }
+
+    destroy() {
+        clearTimeout(this.timeoutID);
+        delete this.connection;
+        delete this.instance;
     }
 };

--- a/src/plugins/PeerConnectionStats.js
+++ b/src/plugins/PeerConnectionStats.js
@@ -108,6 +108,9 @@ module.exports = class PeerConnectionStats {
         }
     }
 
+    /**
+     * Plugin destructor, responsible for removing all callbacks & bindings so that things are garbage-collected
+     */
     destroy() {
         clearTimeout(this.timeoutID);
         delete this.connection;


### PR DESCRIPTION
## Description

This PR improves Device Renderer destruction, in hopes of it getting garbage-collected when we don't need it anymore.

Most event handlers lambda were moved to class methods, so that they could be properly removed, and most plugins had `destroy` functions added, and called in the Device Renderer `destroy`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
