### PR TITLE
Simplify click outside overlay detection

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -68,7 +68,7 @@ module.exports = class DeviceRenderer {
         this.y = 0;
 
         document.addEventListener('click', (event) => {
-            if (!this.hasSomeParentTheClass(event.target, 'gm-overlay')
+            if (event.target.closest('.gm-overlay') === null
                 && !event.target.classList.contains('gm-icon-button')
                 && !event.target.classList.contains('gm-dont-close')) {
                 this.emit('close-overlays');
@@ -156,20 +156,6 @@ module.exports = class DeviceRenderer {
         this.callbacks[eventTag].forEach((callback) => {
             callback(payload);
         });
-    }
-
-    /**
-     * Look for a class applied in a element parent tree.
-     *
-     * @param  {HTMLElement} element   DOM element to check.
-     * @param  {string}      className Class name to look for.
-     * @return {boolean}               Whether or not the class has been found in the given element parents.
-     */
-    hasSomeParentTheClass(element, className) {
-        if (element.classList && element.classList.contains(className)) {
-            return true;
-        }
-        return element.parentNode && this.hasSomeParentTheClass(element.parentNode, className);
     }
 
     /**


### PR DESCRIPTION
## Description

Following a suggestion from @jparez , this small PR simplifies the detecting when a click outside the overlay is done.

## Type of change

- [x] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers. (thanks @jparez)
- [ ] I have made corresponding changes to the documentation (README.md).
- [x] I've checked my modifications for any breaking changes.
