### PR TITLE
Assign options to randomly named property

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -23,11 +23,12 @@ module.exports = class DeviceRenderer {
      * @param {Object}      options Instance configuration options.
      */
     constructor(domRoot, options) {
+        this.identifier = Math.random() * 100;
         this.timeoutCallbacks = [];
         this.videoBackupStyleBackground = '';
 
         // Options associated with this instance
-        this.options = options;
+        this[this.identifier.toString()] = options;
 
         // Websocket & WebRTC connection state
         this.initialized = false;
@@ -81,11 +82,11 @@ module.exports = class DeviceRenderer {
      */
     addCustomPlugins() {
         const pluginInitMap = [
-            {enabled: this.options.touch || this.options.mouse, class: CoordinateUtils},
-            {enabled: this.options.keyboard, class: KeyboardEvents},
-            {enabled: this.options.mouse, class: MouseEvents},
-            {enabled: this.options.gamepad, class: Gamepad, params: [this.gamepadManager, this.options.i18n]},
-            {enabled: this.options.camera || this.options.microphone, class: MediaManager},
+            {enabled: this[this.identifier.toString()].touch || this[this.identifier.toString()].mouse, class: CoordinateUtils},
+            {enabled: this[this.identifier.toString()].keyboard, class: KeyboardEvents},
+            {enabled: this[this.identifier.toString()].mouse, class: MouseEvents},
+            {enabled: this[this.identifier.toString()].gamepad, class: Gamepad, params: [this.gamepadManager, this[this.identifier.toString()].i18n]},
+            {enabled: this[this.identifier.toString()].camera || this[this.identifier.toString()].microphone, class: MediaManager},
         ];
 
         pluginInitMap.forEach((plugin) => {
@@ -199,7 +200,7 @@ module.exports = class DeviceRenderer {
             this.reconnecting = true;
         }
 
-        this.webRTCWebsocket = new WebSocket(this.options.webRTCUrl, this.webRTCWebsocketName);
+        this.webRTCWebsocket = new WebSocket(this[this.identifier.toString()].webRTCUrl, this.webRTCWebsocketName);
         this.webRTCWebsocket.onopen = this.sendAuthenticationToken.bind(this);
         this.webRTCWebsocket.onmessage = this.onWebSocketMessage.bind(this);
         this.webRTCWebsocket.onerror = this.onWebSocketMessage.bind(this);
@@ -285,7 +286,7 @@ module.exports = class DeviceRenderer {
     sendAuthenticationToken() {
         const tokenRequest = {
             type: 'token',
-            token: this.options.token,
+            token: this[this.identifier.toString()].token,
         };
 
         if (this.isWebsocketOpen(this.webRTCWebsocket)) {
@@ -378,20 +379,20 @@ module.exports = class DeviceRenderer {
 
         const iceServers = [];
 
-        if (Array.isArray(this.options.stun)) {
-            this.options.stun.forEach((stunServer) => {
+        if (Array.isArray(this[this.identifier.toString()].stun)) {
+            this[this.identifier.toString()].stun.forEach((stunServer) => {
                 iceServers.push(stunServer);
             });
-        } else if (Object.keys(this.options.stun).length > 0) {
-            iceServers.push(this.options.stun);
+        } else if (Object.keys(this[this.identifier.toString()].stun).length > 0) {
+            iceServers.push(this[this.identifier.toString()].stun);
         }
 
-        if (Array.isArray(this.options.turn)) {
-            this.options.turn.forEach((turnServer) => {
+        if (Array.isArray(this[this.identifier.toString()].turn)) {
+            this[this.identifier.toString()].turn.forEach((turnServer) => {
                 iceServers.push(turnServer);
             });
-        } else if (Object.keys(this.options.turn).length > 0) {
-            iceServers.push(this.options.turn);
+        } else if (Object.keys(this[this.identifier.toString()].turn).length > 0) {
+            iceServers.push(this[this.identifier.toString()].turn);
         }
 
         const config = {
@@ -479,7 +480,7 @@ module.exports = class DeviceRenderer {
                     this.dispatchEvent('video', {msg: 'play automatically allowed without sound'});
                     const popup = document.createElement('div');
                     popup.classList.add('gm-click-to-unmute');
-                    popup.innerHTML = this.options.i18n.UNMUTE_INVITE || 'By default, the sound has been turned off, '
+                    popup.innerHTML = this[this.identifier.toString()].i18n.UNMUTE_INVITE || 'By default, the sound has been turned off, '
                         + 'please click anywhere to re-enable audio';
                     this.videoWrapper.prepend(popup);
                     const addSound = () => {
@@ -527,7 +528,7 @@ module.exports = class DeviceRenderer {
             div.classList.add('gm-overlay-cant-connect');
             div.classList.add('gm-video-overlay');
             this.videoWrapper.prepend(div);
-            if (this.options.connectionFailedURL) {
+            if (this[this.identifier.toString()].connectionFailedURL) {
                 message = message.replace(
                     '{DOC_AVAILABLE}',
                     '</br>See <a href="">help</a> to setup TURN configuration.'
@@ -535,7 +536,7 @@ module.exports = class DeviceRenderer {
                 const openDocumentationLink = () => {
                     this.dispatchEvent('iceConnectionStateDocumentation', {msg: 'clicked'});
                     div.remove();
-                    window.open(this.options.connectionFailedURL, '_blank');
+                    window.open(this[this.identifier.toString()].connectionFailedURL, '_blank');
                 };
                 div.addEventListener('click', openDocumentationLink);
                 div.addEventListener('touchend', openDocumentationLink);
@@ -702,8 +703,8 @@ module.exports = class DeviceRenderer {
         if (this.fileUpload) {
             const msg = {
                 type: 'address',
-                fileUploadAddress: this.options.fileUploadUrl,
-                token: this.options.token,
+                fileUploadAddress: this[this.identifier.toString()].fileUploadUrl,
+                token: this[this.identifier.toString()].token,
             };
 
             if (this.fileUpload.loaderWorker) {


### PR DESCRIPTION
## Description

When I instantiate the player, if I already did it and I want to initiate it again without refresh, some options are not refreshed and the old values will be used.
Assign to a random named property instead of `options` works

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
