### PR TITLE
Remove Lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/Genymobile/genymotion-device-web-player#readme",
   "dependencies": {
-    "lodash": "^4.17.21",
     "loglevel": "^1.8.0",
     "webrtc-adapter": "^7.7.1"
   },

--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const DeviceRenderer = require('./DeviceRenderer');
-const defaultsDeep = require('lodash/defaultsDeep');
 
 // Plugins
 const GPS = require('./plugins/GPS');
@@ -142,20 +141,25 @@ module.exports = class DeviceRendererFactory {
         if (typeof options === 'undefined') {
             options = {};
         }
-        options = defaultsDeep(options, defaultOptions);
-        options.webRTCUrl = webRTCUrl;
+        const rendererOptions = {};
+        Object.assign(rendererOptions, defaultOptions, options);
+        rendererOptions.webRTCUrl = webRTCUrl;
         // if we have at least one button to setup, we will instantiate the "buttons" plugin
-        options.buttons = options.volume || options.rotation || options.navbar || options.power;
+        rendererOptions.buttons =
+            rendererOptions.volume ||
+            rendererOptions.rotation ||
+            rendererOptions.navbar ||
+            rendererOptions.power;
 
         log.debug('Creating genymotion display on ' + webRTCUrl);
         dom.classList.add('device-renderer-instance');
-        dom.classList.add('gm-template-' + options.template);
-        document.body.classList.add('gm-template-' + options.template + '-body');
+        dom.classList.add('gm-template-' + rendererOptions.template);
+        document.body.classList.add('gm-template-' + rendererOptions.template + '-body');
 
         // Load template before creating the Device Renderer that is using HTML elements
-        this.loadTemplate(dom, this.templates[options.template], options);
+        this.loadTemplate(dom, this.templates[rendererOptions.template], rendererOptions);
 
-        const instance = new RendererClass(dom, options);
+        const instance = new RendererClass(dom, rendererOptions);
         this.instances.push(instance);
 
         this.addPlugins(instance, instance.options);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,7 +6175,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.10, lodash@^4.17.14, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Description

defaultsDeep was causing a weird bug on Shadow's side because of change-in-place behaviour. I found it clearer to use `Object.assign` from the default library.

Lodash wasn't used anywhere else, so let's remove the dependency.

### Notes

- [Object.assign makes a shallow assignment](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Object/assign). I'm in the process of checking if this doesn't break anything.
- I would have prefered to use the [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax), but it's only available in ES2018 and gulp is holding us back

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
