### PR TITLE
[PLAYER-2] bind keypress envent on root div instead of window object

### DIFF
--- a/src/plugins/KeyboardEvents.js
+++ b/src/plugins/KeyboardEvents.js
@@ -234,7 +234,7 @@ module.exports = class KeyboardEvents {
             }
             this.instance.root.focus();
             this.keyboardCallbacks.forEach((item, index, array) => {
-                array[index].removeListener = this.instance.addListener(window, item.event, item.handler);
+                array[index].removeListener = this.instance.addListener(this.instance.root, item.event, item.handler);
             });
             this.isListenerAdded = true;
         }


### PR DESCRIPTION
## Description
Fix bug when typing charater outside of player events were send to the instance

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] I've checked my modifications for any breaking changes.
