### PR TITLE
[PLAYER-7] fix issue when destroy a not fully initialized player

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -876,6 +876,14 @@ module.exports = class DeviceRenderer {
      * This method also calls recursively the destroy methods on the plugins if they exist.
      */
     destroy() {
+        /**
+         *  if the websocket is in connecting state,
+         *  we can't destroy the instance cause object is not fully initialized
+         */
+        if (this.webRTCWebsocket.readyState === 0) {
+            return;
+        }
+
         this.removeAllListeners();
         this.disconnect();
         this.peerConnectionStats?.destroy();


### PR DESCRIPTION
## Description

When calling setupRender and destroy() in a loop destroy() destroy try to delete object not already load

see https://genymobile.atlassian.net/browse/PLAYER-7

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
