### PR TITLE
cleanup logerror for gamepadmanager

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -151,7 +151,7 @@ gulp.task('app-js', async function() {
             ]
         }))))
         .pipe(streamify(concat('device-renderer.min.js')))
-        .pipe(gulpif(util.env.production, streamify(uglify())))
+        .pipe(gulpif(util.env.production, streamify(uglify({keep_fnames : true}))))
         .pipe(gulp.dest(PATHS.DEST.LIB.JS));
 });
 

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -110,20 +110,15 @@ module.exports = class DeviceRenderer {
             {enabled: this.options.clipboard, class: Clipboard, params: [this.options.i18n]},
             {enabled: this.options.streamBitrate, class: StreamBitrate, params: [this.options.i18n]},
             {enabled: this.options.camera, class: Camera, params: [this.options.i18n], dependencies:[MediaManager]},
+            {enabled: this.options.fileUpload, class: FileUpload, params: [this.options.i18n]},
             {enabled: this.options.battery, class: Battery, params: [this.options.i18n]},
             {enabled: this.options.gps, class: GPS, params: [this.options.i18n, this.options.gpsSpeedSupport]},
             {enabled: this.options.capture, class: Screencast, params: [this.options.i18n]},
             {enabled: this.options.streamResolution, class: StreamResolution},
-            {
-                enabled: this.options.buttons,
-                class: ButtonsEvents,
-                params: [this.options.i18n, this.options.translateHomeKey]
-            },
             {enabled: this.options.touch || this.options.mouse, class: CoordinateUtils},
             {enabled: this.options.keyboard, class: KeyboardEvents},
             {enabled: this.options.mouse, class: MouseEvents},
             {enabled: this.options.gamepad, class: Gamepad, params: [this.options.i18n], dependencies:[GamepadManager]},
-            {enabled: this.options.fileUpload, class: FileUpload, params: [this.options.i18n]},
             {enabled: this.options.identifiers, class: Identifiers, params: [this.options.i18n]},
             {enabled: this.options.network, class: Network, params: [this.options.i18n]},
             {enabled: this.options.phone, class: Phone, params: [this.options.i18n]},
@@ -131,6 +126,11 @@ module.exports = class DeviceRenderer {
             {enabled: this.options.diskIO, class: IOThrottling, params: [this.options.i18n]},
             {enabled: this.options.biometrics, class: FingerPrint},
             {enabled: this.options.microphone, dependencies:[MediaManager]},
+            {
+                enabled: this.options.buttons,
+                class: ButtonsEvents,
+                params: [this.options.i18n, this.options.translateHomeKey]
+            },
         ];
 
         return pluginInitMap;

--- a/src/plugins/Gamepad.js
+++ b/src/plugins/Gamepad.js
@@ -116,7 +116,6 @@ module.exports = class Gamepad extends OverlayPlugin {
     handleGamepadPlugged(event) {
         log.debug('Gamepad plugged');
         const gamepad = event.detail;
-        log.debug(gamepad);
         this.generateContent();
         this.sendGamepadPlugEvent(gamepad.hostIndex, gamepad.name.split(' ').join('_'),
             gamepad.vendorID, gamepad.productID);
@@ -167,7 +166,7 @@ module.exports = class Gamepad extends OverlayPlugin {
     }
 
     handleConfirmation(message) {
-        log.debug('Plugin confirmation');
+        log.debug('Gamepad plugin confirmation');
         const values = message.split(' ');
         if (values[0] === 'gamepad_plugin_confirmation' && values.length === 3) {
             this.instance.gamepadManager.listenForInputs(parseInt(values[1]), parseInt(values[2]));
@@ -175,8 +174,6 @@ module.exports = class Gamepad extends OverlayPlugin {
     }
 
     onGamepadButtonPressed(event) {
-        log.debug('button pressed');
-
         const json = {
             channel : 'vinput' , messages : [
                 'gamepad_press ' + event.detail.gamepadIndex + ' ' + event.detail.buttonIndex
@@ -186,8 +183,6 @@ module.exports = class Gamepad extends OverlayPlugin {
     }
 
     onGamepadButtonReleased(event) {
-        log.debug('button released');
-
         const json = {
             channel : 'vinput' , messages : [
                 'gamepad_release ' + event.detail.gamepadIndex + ' ' + event.detail.buttonIndex
@@ -197,8 +192,6 @@ module.exports = class Gamepad extends OverlayPlugin {
     }
 
     onGamepadAxisChanged(event) {
-        log.debug('Axis changed');
-
         const json = {
             channel : 'vinput' , messages : [
                 'gamepad_axis ' + event.detail.gamepadIndex + ' ' + event.detail.axisIndex + ' ' + event.detail.value

--- a/src/plugins/GamepadManager.js
+++ b/src/plugins/GamepadManager.js
@@ -502,7 +502,6 @@ module.exports = class GamepadManager {
                 });
             } else {
                 log.error(`could not use vibration actuator for controller ${guestIndex}`);
-                log.debug(gamepad);
             }
         } else if (gamepad.hapticActuators && gamepad.hapticActuators[0]) { // firefox
             const actuator = gamepad.hapticActuators[0];
@@ -510,7 +509,6 @@ module.exports = class GamepadManager {
                 actuator.pulse(strong, 200);
             } else {
                 log.error(`could not use haptic actuator for controller ${guestIndex}`);
-                log.debug(gamepad);
             }
         } else { // unrecognised, for example DualSense
             log.error(`no vibration actuator for controller ${guestIndex}`);


### PR DESCRIPTION
## Description

- cleanup logerror for gamepadmanager
- adding an option to preserve class and fn's name when file are uglify in prod mode. In order to have class.name works when file is uglify (cause name's class are replace by shorter name), see #72 at plugin.class.name

Jira issue: https://genymobile.atlassian.net/browse/PLAYER-8


## Related PRs
- #73 
- #72