### PR TITLE
[PLAYER-18] api manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ or check the [PaaS documentation](https://docs.genymotion.com/paas/01_Requiremen
     // Device renderer instanciation
     const {DeviceRendererFactory} = window.index;
     const deviceRendererFactory = new DeviceRendererFactory();
-    const renderer = deviceRendererFactory.setupRenderer(
+    const playerAPI = deviceRendererFactory.setupRenderer(
         container, // the container element or element ID to use
         webrtcAddress, // the websocket address of your instance connector
         options, // options object to enable or disable features
@@ -111,9 +111,39 @@ or check the [PaaS documentation](https://docs.genymotion.com/paas/01_Requiremen
 
     // Disconnect the device renderer, closing any open data channels.
     window.addEventListener('beforeunload', function () {
-        renderer.disconnect();
+        playerAPI.disconnect();
     });
 </script>
+```
+
+## Player API
+
+plugin options and websocket communication can be handle trought the API object returned by setupRenderer fn.
+
+Built-in exposed fn are
+
+### `getRegisteredFunctions`
+
+which return the list of available fn with an optionnal description
+
+### `disconnect`
+
+which disconnect player from VM and cleanup memory listener
+
+### `addEventListener`
+
+used to listen messages emit from VM such as 'fingerprint', 'gps', 'BATTERY_LEVEL'
+
+```html
+addEventListener('fingerprint', (msg)=>{ console.log(msg) })
+```
+
+### `sendData`
+
+used to send message to VM.
+
+```html
+sendData({ channel: 'battery', messages: ['set state level 10', 'set state status true'], })
 ```
 
 ## Features & options

--- a/README.md
+++ b/README.md
@@ -118,21 +118,21 @@ or check the [PaaS documentation](https://docs.genymotion.com/paas/01_Requiremen
 
 ## Player API
 
-plugin options and websocket communication can be handle trought the API object returned by setupRenderer function.
+Plugin options and websocket communication can be handled through the API object returned by the `setupRenderer` function.
 
 Built-in exposed functions are
 
 ### `getRegisteredFunctions`
 
-which return the list of available functions with an optionnal description
+which returns the list of available functions with an optional description
 
 ### `disconnect`
 
-which disconnect player from VM and cleanup memory listener
+which disconnects the player from the VM and cleanups the memory listener
 
 ### `addEventListener`
 
-used to listen messages emit from VM such as 'fingerprint', 'gps', 'BATTERY_LEVEL'
+used to listen to messages emitted from the VM such as 'fingerprint', 'gps', 'BATTERY_LEVEL'
 
 ```html
 addEventListener('fingerprint', (msg)=>{ console.log(msg) })
@@ -140,7 +140,7 @@ addEventListener('fingerprint', (msg)=>{ console.log(msg) })
 
 ### `sendData`
 
-used to send message to VM.
+used to send messages to the VM.
 
 ```html
 sendData({ channel: 'battery', messages: ['set state level 10', 'set state status true'], })

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ or check the [PaaS documentation](https://docs.genymotion.com/paas/01_Requiremen
     // Device renderer instanciation
     const {DeviceRendererFactory} = window.index;
     const deviceRendererFactory = new DeviceRendererFactory();
-    const playerAPI = deviceRendererFactory.setupRenderer(
+    const rendererAPI = deviceRendererFactory.setupRenderer(
         container, // the container element or element ID to use
         webrtcAddress, // the websocket address of your instance connector
         options, // options object to enable or disable features
@@ -118,13 +118,13 @@ or check the [PaaS documentation](https://docs.genymotion.com/paas/01_Requiremen
 
 ## Player API
 
-plugin options and websocket communication can be handle trought the API object returned by setupRenderer fn.
+plugin options and websocket communication can be handle trought the API object returned by setupRenderer function.
 
-Built-in exposed fn are
+Built-in exposed functions are
 
 ### `getRegisteredFunctions`
 
-which return the list of available fn with an optionnal description
+which return the list of available functions with an optionnal description
 
 ### `disconnect`
 

--- a/src/APIManager.js
+++ b/src/APIManager.js
@@ -17,7 +17,7 @@ module.exports = class APIManager {
         // record fn to get registered functions
         this.registerFunction(
             'getRegisteredFunctions',
-            () => this.listRegisteredFunctions(),
+            () => this.getRegisteredFunctions(),
             'list all registered functions',
         );
 
@@ -54,7 +54,7 @@ module.exports = class APIManager {
         this.instance.registerEventCallback(event, fn);
     }
 
-    listRegisteredFunctions() {
+    getRegisteredFunctions() {
         const exposedFunctionsDescription = Object.entries(this.apiFunctions).reduce((acc, val) => {
             acc[val[0]] = val[1].description;
             return acc;
@@ -62,6 +62,10 @@ module.exports = class APIManager {
         return exposedFunctionsDescription;
     }
 
+    /**
+     * Get exposed API functions
+     * @returns {Array} list of api {apiName: string, apiDescription: string}
+     */
     getExposedApiFunctions() {
         const exposedFunctions = Object.entries(this.apiFunctions).reduce((acc, val) => {
             acc[val[0]] = val[1].fn;

--- a/src/APIManager.js
+++ b/src/APIManager.js
@@ -54,6 +54,10 @@ module.exports = class APIManager {
         this.instance.registerEventCallback(event, fn);
     }
 
+    /**
+     * Get exposed API description
+     * @returns {Array} list of api description {apiName: string, apiDescription: string}
+     */
     getRegisteredFunctions() {
         const exposedFunctionsDescription = Object.entries(this.apiFunctions).reduce((acc, val) => {
             acc[val[0]] = val[1].description;
@@ -64,7 +68,7 @@ module.exports = class APIManager {
 
     /**
      * Get exposed API functions
-     * @returns {Array} list of api {apiName: string, apiDescription: string}
+     * @returns {Array} list of api fn {apiName: fn}
      */
     getExposedApiFunctions() {
         const exposedFunctions = Object.entries(this.apiFunctions).reduce((acc, val) => {

--- a/src/APIManager.js
+++ b/src/APIManager.js
@@ -1,0 +1,17 @@
+'use strict';
+
+class APIManager {
+    constructor() {
+        this.apiFunctions = {};
+    }
+
+    registerFunction(name, fn) {
+        if (this.apiFunctions[name]) {
+            throw new Error(`Function ${name} is already registered.`);
+        }
+        this.apiFunctions[name] = fn;
+    }
+}
+
+const apiManager = new APIManager();
+module.exports = apiManager;

--- a/src/APIManager.js
+++ b/src/APIManager.js
@@ -1,17 +1,72 @@
 'use strict';
 
-class APIManager {
-    constructor() {
+module.exports = class APIManager {
+    constructor(instance) {
+        this.instance = instance;
         this.apiFunctions = {};
+
+        // record fn to send data to instance
+        this.registerFunction(
+            'sendData',
+            (json) => {
+                this.instance.sendEvent(json);
+            },
+            'send data to WS messages of player, must be a JSON object. Example: {type: "MOUSE_PRESS", x: 100, y: 100}',
+        );
+
+        // record fn to get registered functions
+        this.registerFunction(
+            'getRegisteredFunctions',
+            () => this.listRegisteredFunctions(),
+            'list all registered functions',
+        );
+
+        // record fn to get registered functions
+        this.registerFunction(
+            'addEventListener',
+            (event, fn) => {
+                return this.addEventListener(event, fn);
+            },
+            'attach event listener to WS messages of player',
+        );
+
+        // record fn to disconnect from the instance
+        this.registerFunction(
+            'disconnect',
+            () => {
+                this.instance.disconnect();
+            },
+            'disconnect from the instance',
+        );
     }
 
-    registerFunction(name, fn) {
+    registerFunction(name, fn, description = '') {
         if (this.apiFunctions[name]) {
             throw new Error(`Function ${name} is already registered.`);
         }
-        this.apiFunctions[name] = fn;
+        this.apiFunctions[name] = {
+            fn,
+            description,
+        };
     }
-}
+    addEventListener(event, fn) {
+        // expose listener to ws instance
+        this.instance.registerEventCallback(event, fn);
+    }
 
-const apiManager = new APIManager();
-module.exports = apiManager;
+    listRegisteredFunctions() {
+        const exposedFunctionsDescription = Object.entries(this.apiFunctions).reduce((acc, val) => {
+            acc[val[0]] = val[1].description;
+            return acc;
+        }, {});
+        return exposedFunctionsDescription;
+    }
+
+    getExposedApiFunctions() {
+        const exposedFunctions = Object.entries(this.apiFunctions).reduce((acc, val) => {
+            acc[val[0]] = val[1].fn;
+            return acc;
+        }, {});
+        return exposedFunctions;
+    }
+};

--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -4,7 +4,7 @@ const DeviceRenderer = require('./DeviceRenderer');
 const defaultsDeep = require('lodash/defaultsDeep');
 
 const store = require('./store');
-const apiManager = require('./APIManager');
+const APIManager = require('./APIManager');
 
 const log = require('loglevel');
 log.setDefaultLevel('debug');
@@ -145,14 +145,14 @@ module.exports = class DeviceRendererFactory {
         const instance = new RendererClass(dom, options);
         store(instance);
 
-        instance.apiManager = apiManager;
+        instance.apiManager = new APIManager(instance);
 
         this.instances.push(instance);
 
         this.addPlugins(instance);
         instance.onWebRTCReady();
 
-        return instance.apiManager.apiFunctions;
+        return instance.apiManager.getExposedApiFunctions();
     }
 
     /**

--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -119,7 +119,7 @@ module.exports = class DeviceRendererFactory {
      * @param  {boolean}            options.turn.default           Whether or not we should use the TURN servers by default. Default: false.
      * @param  {string}             options.giveFeedbackLink       URL to the feedback form. Default: 'https://github.com/orgs/Genymobile/discussions'
      * @param  {Object}             RendererClass                  Class to be instanciated. Defaults to DeviceRenderer.
-     * @return {DeviceRenderer}                                    The device renderer instance.
+     * @return {Array}                                             An array of API for device renderer instance, see return of APIManager.getExposedApiFunctions.
      */
     setupRenderer(dom, webRTCUrl, options, RendererClass = DeviceRenderer) {
         if (typeof dom === 'string') {

--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -4,6 +4,7 @@ const DeviceRenderer = require('./DeviceRenderer');
 const defaultsDeep = require('lodash/defaultsDeep');
 
 const store = require('./store');
+const apiManager = require('./APIManager');
 
 const log = require('loglevel');
 log.setDefaultLevel('debug');
@@ -144,12 +145,14 @@ module.exports = class DeviceRendererFactory {
         const instance = new RendererClass(dom, options);
         store(instance);
 
+        instance.apiManager = apiManager;
+
         this.instances.push(instance);
 
         this.addPlugins(instance);
         instance.onWebRTCReady();
 
-        return instance;
+        return instance.apiManager.apiFunctions;
     }
 
     /**

--- a/src/plugins/MediaManager.js
+++ b/src/plugins/MediaManager.js
@@ -31,6 +31,16 @@ module.exports = class MediaManager {
         this.videoWidth = videoWidth;
         this.videoHeight = videoHeight;
         this.videoWithMicrophone = videoWithMicrophone;
+
+        //register mute/unmute to exposed API
+        this.instance.apiManager.registerFunction('mute', () => {
+            this.instance.video.isMuted = true;
+            this.instance.video.muted = true;
+        });
+        this.instance.apiManager.registerFunction('unmute', () => {
+            this.instance.video.isMuted = false;
+            this.instance.video.muted = false;
+        });
     }
 
     /**

--- a/src/plugins/MediaManager.js
+++ b/src/plugins/MediaManager.js
@@ -32,7 +32,7 @@ module.exports = class MediaManager {
         this.videoHeight = videoHeight;
         this.videoWithMicrophone = videoWithMicrophone;
 
-        //register mute/unmute to exposed API
+        // register mute/unmute to exposed API
         this.instance.apiManager.registerFunction('mute', () => {
             this.instance.video.isMuted = true;
             this.instance.video.muted = true;

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -28,7 +28,8 @@ module.exports = class MouseEvents {
      * @param {Event} event Event.
      */
     onMousePressEvent(event) {
-        /** At launch the sound is muted until a click is performed on the <video>
+        /**
+         * At launch the sound is muted until a click is performed on the <video>
          * `this.instance.mediaManager.isMuted` is necessary to force the sound to be muted even if the user clicked on the video
          */
         this.instance.video.muted = !this.instance.mediaManager.isMuted ? this.instance.video.muted : false;

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -28,7 +28,10 @@ module.exports = class MouseEvents {
      * @param {Event} event Event.
      */
     onMousePressEvent(event) {
-        this.instance.video.muted = false;
+        /** At launch the sound is muted until a click is performed on the <video>
+         * `this.instance.mediaManager.isMuted` is necessary to force the sound to be muted even if the user clicked on the video
+         */
+        this.instance.video.muted = !this.instance.mediaManager.isMuted ? this.instance.video.muted : false;
         if (event.button !== 0) {
             return;
         }

--- a/tests/mocks/DeviceRenderer.js
+++ b/tests/mocks/DeviceRenderer.js
@@ -39,6 +39,9 @@ module.exports = class DeviceRenderer extends Original {
             },
             subscribe: jest.fn(),
         };
+        this.apiManager = {
+            registerFunction: jest.fn(),
+        };
     }
 
     /**


### PR DESCRIPTION
## Description

Add an `APIManager` to expose the player API.

This is a breaking change since `setupRendere`r now returns the API, not the `DeviceRendererFactory` object.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
