### PR TITLE
[PLAYER-19] pre-keybinding refacto keyboard enable/disable and overlay

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
-    "extends": ["eslint:recommended"],
+    "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+    "plugins": ["prettier"],
     "env": {
         "browser": true,
         "es6": true,
@@ -10,16 +11,18 @@
         "ecmaVersion": 2020
     },
     "rules": {
-        // Possible errors
-        "no-console": "error",
-        "no-extra-parens": [
+        "prettier/prettier": [
             "error",
-            "all",
             {
+                "insertPragma": true,
+                "requirePragma": true,
                 "nestedBinaryExpressions": false,
                 "enforceForArrowConditionals": false
             }
         ],
+        "comma-spacing": ["error", {"before": false, "after": true}],
+        "no-console": "warn",
+        "no-extra-parens": "off",
         "no-loss-of-precision": "error",
         "no-promise-executor-return": "error",
         "no-template-curly-in-string": "error",
@@ -71,7 +74,7 @@
         "multiline-comment-style": ["error", "starred-block"],
         "new-cap": ["error", {"properties": false}],
         "new-parens": "error",
-        "newline-per-chained-call": "error",
+        "newline-per-chained-call": "off",
         "no-multi-assign": "error",
         "no-multiple-empty-lines": ["error", {"max": 1}],
         "no-trailing-spaces": "error",
@@ -80,7 +83,14 @@
         "quotes": ["error", "single", {"avoidEscape": true}],
         "semi": ["error", "always"],
         "semi-style": ["error", "last"],
-        "space-before-function-paren": ["error", "never"],
+        "space-before-function-paren": [
+            "error",
+            {
+                "anonymous": "always",
+                "named": "never",
+                "asyncArrow": "never"
+            }
+        ],
         "space-in-parens": ["error", "never"],
         "spaced-comment": ["error", "always"],
         // ECMAScript 6

--- a/gulp/graspify-squery.js
+++ b/gulp/graspify-squery.js
@@ -23,8 +23,8 @@ const options = {
 module.exports = transformTools.makeStringTransform('graspify', options, (content, opts, done) => {
     try {
         // Normalize plain replacements
-        opts.opts = opts.opts ? Array.isArray(opts.opts) ? opts.opts : [opts.opts] : [];
-        opts.config = opts.config ? Array.isArray(opts.config) ? opts.config : [opts.config] : [];
+        opts.opts = opts.opts ? (Array.isArray(opts.opts) ? opts.opts : [opts.opts]) : [];
+        opts.config = opts.config ? (Array.isArray(opts.config) ? opts.config : [opts.config]) : [];
 
         // Merge opts & config for the full list of replacements an loop over
         [].concat(opts.opts, opts.config).forEach((args) => {

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -95,7 +95,7 @@ module.exports = class DeviceRenderer {
                 !event.target.classList.contains('gm-icon-button') &&
                 !event.target.classList.contains('gm-dont-close')
             ) {
-                this.emit('close-overlays');
+                this.store.dispatch({type: 'OVERLAY_OPEN', payload: {toOpen: false}});
             }
         };
         this.addListener(document, 'click', this.clickHandlerCloseOverlay);

--- a/src/plugins/BasebandRIL.js
+++ b/src/plugins/BasebandRIL.js
@@ -224,25 +224,7 @@ module.exports = class BasebandRIL extends OverlayPlugin {
         this.widget.appendChild(this.form);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**
@@ -307,6 +289,7 @@ module.exports = class BasebandRIL extends OverlayPlugin {
             }
         }
 
-        this.toggleWidget();
+        // close the widget
+        this.instance.store.dispatch({type: 'OVERLAY_OPEN', payload: {overlayID: this.overlayID, toOpen: false}});
     }
 };

--- a/src/plugins/Battery.js
+++ b/src/plugins/Battery.js
@@ -110,8 +110,6 @@ module.exports = class Battery extends OverlayPlugin {
         this.widget.appendChild(close);
         this.widget.appendChild(this.container);
 
-        // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
     }
 
@@ -190,19 +188,6 @@ module.exports = class Battery extends OverlayPlugin {
     /**
      * Display or hide the widget.
      */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
-    }
 
     /**
      * Toggle Instance charging status between 'charging' and 'discharging';

--- a/src/plugins/Clipboard.js
+++ b/src/plugins/Clipboard.js
@@ -107,7 +107,6 @@ module.exports = class Clipboard extends OverlayPlugin {
         };
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
     }
 
@@ -115,19 +114,10 @@ module.exports = class Clipboard extends OverlayPlugin {
      * Display or hide the widget.
      */
     toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
+        super.toggleWidget();
+        if (this.instance.store.getters.isWidgetOpened(this.overlayID)) {
             this.clipboardInput.value = this.clipboard;
-        } else {
-            this.instance.emit('keyboard-enable');
-            this.widget.onclose();
         }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/FileUpload.js
+++ b/src/plugins/FileUpload.js
@@ -163,7 +163,6 @@ module.exports = class FileUpload extends OverlayPlugin {
         this.widget.appendChild(this.container);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
     }
 
@@ -171,10 +170,9 @@ module.exports = class FileUpload extends OverlayPlugin {
      * Display or hide the widget.
      */
     toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
+        super.toggleWidget();
+
+        if (this.instance.store.getters.isWidgetOpened(this.overlayID)) {
             this.displayStep(this.currentStep);
             // Force refresh upload screen content. Otherwise, installing status may not appear.
             if (this.currentStep === 'uploadScreen') {
@@ -189,12 +187,7 @@ module.exports = class FileUpload extends OverlayPlugin {
             if (this.currentStep === 'successScreen' || this.currentStep === 'errorScreen') {
                 this.currentStep = 'homeScreen';
             }
-            this.instance.emit('keyboard-enable');
         }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/FileUpload.js
+++ b/src/plugins/FileUpload.js
@@ -302,7 +302,7 @@ module.exports = class FileUpload extends OverlayPlugin {
             case 'success':
                 this.displayStep('successScreen');
                 // On flashing success, force display success screen
-                if (this.flashing && this.widget.classList.contains('gm-hidden')) {
+                if (this.flashing && !this.instance.store.getters.isWidgetOpened(this.overlayID)) {
                     this.toggleWidget();
                 }
                 this.flashing = false;
@@ -313,7 +313,7 @@ module.exports = class FileUpload extends OverlayPlugin {
             case 'install_error':
                 this.displayStep('errorScreen');
                 // On flashing error, force display errorscreen
-                if (this.flashing && this.widget.classList.contains('gm-hidden')) {
+                if (this.flashing && !this.instance.store.getters.isWidgetOpened(this.overlayID)) {
                     this.toggleWidget();
                 }
                 this.flashing = false;

--- a/src/plugins/FingerPrint.js
+++ b/src/plugins/FingerPrint.js
@@ -153,7 +153,7 @@ module.exports = class FingerPrint extends OverlayPlugin {
         this.toolbarBtnImage = document.createElement('div');
         this.toolbarBtnImage.className = 'gm-icon-button gm-fingerprint-button';
         this.toolbarBtnImage.title = this.i18n.FINGERPRINT_TITLE || 'Biometrics';
-        this.toolbarBtn.onclick = () => this.toggleWidget();
+        this.toolbarBtn.onclick = this.toggleWidget.bind(this);
         this.toolbarBtn.appendChild(this.toolbarBtnImage);
         toolbar.appendChild(this.toolbarBtn);
     }
@@ -284,43 +284,16 @@ module.exports = class FingerPrint extends OverlayPlugin {
         // Add close button
         const close = document.createElement('div');
         close.className = 'gm-close-btn';
-        close.onclick = () => this.closeWidget();
+        close.onclick = this.toggleWidget.bind(this);
 
         this.widget.appendChild(close);
         this.widget.appendChild(this.container);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
 
         // post setup
         this.disableBody();
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
-    }
-
-    /**
-     * Close the widget.
-     */
-    closeWidget() {
-        this.instance.emit('keyboard-enable');
-        this.widget.classList.add('gm-hidden');
-        this.toolbarBtnImage.classList.remove('gm-active');
     }
 
     /**
@@ -379,7 +352,7 @@ module.exports = class FingerPrint extends OverlayPlugin {
                 Array.from(document.querySelectorAll('.gm-fingerprint-dialog-button')).forEach((btn) => {
                     btn.classList.remove('gm-loader');
                 });
-                this.closeWidget();
+                this.toggleWidget();
                 break;
             case FINGERPRINT_MESSAGES.toReceive.CURRENT_STATUS_SCANNING:
                 this.state.isScanning = true;

--- a/src/plugins/GPS.js
+++ b/src/plugins/GPS.js
@@ -311,8 +311,7 @@ module.exports = class GPS extends OverlayPlugin {
 
         this.checkForGeolocation();
 
-        // Toggle display
-        this.formWidget.classList.toggle('gm-hidden');
+        // TODO refacto this with 2 different overlay (gps and map)
         this.mapWidget.classList.add('gm-hidden');
         this.toolbarBtnImage.classList.toggle('gm-active');
     }

--- a/src/plugins/GPS.js
+++ b/src/plugins/GPS.js
@@ -113,7 +113,6 @@ module.exports = class GPS extends OverlayPlugin {
         this.mapWidget.appendChild(cancel);
 
         // Render into document
-        this.overlays.push(this.mapWidget);
         this.instance.root.appendChild(this.mapWidget);
     }
 
@@ -206,7 +205,7 @@ module.exports = class GPS extends OverlayPlugin {
      */
     renderGPSForm() {
         // Create elements
-        this.formWidget = document.createElement('div');
+        this.widget = document.createElement('div');
         this.form = document.createElement('form');
         const formWrap = document.createElement('div');
 
@@ -282,38 +281,29 @@ module.exports = class GPS extends OverlayPlugin {
         this.form.appendChild(button);
 
         // Setup
-        this.formWidget.className = 'gm-overlay gm-gps-controls gm-hidden';
+        this.widget.className = 'gm-overlay gm-gps-controls gm-hidden';
 
         // Add close button
         const close = document.createElement('div');
         close.className = 'gm-close-btn';
         close.onclick = this.toggleForm.bind(this);
 
-        this.formWidget.appendChild(close);
-        this.formWidget.appendChild(this.form);
+        this.widget.appendChild(close);
+        this.widget.appendChild(this.form);
 
         // Render into document
-        this.overlays.push(this.formWidget);
-        this.instance.root.appendChild(this.formWidget);
+        this.instance.root.appendChild(this.widget);
     }
 
     /**
      * Display or hide the controls view.
      */
     toggleForm() {
-        // Notify other callers
-        if (this.formWidget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
+        this.toggleWidget();
         this.checkForGeolocation();
 
         // TODO refacto this with 2 different overlay (gps and map)
         this.mapWidget.classList.add('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/Gamepad.js
+++ b/src/plugins/Gamepad.js
@@ -88,7 +88,6 @@ module.exports = class Gamepad extends OverlayPlugin {
         this.widget.appendChild(this.container);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
     }
 
@@ -148,23 +147,6 @@ module.exports = class Gamepad extends OverlayPlugin {
         };
 
         this.instance.sendEvent(json);
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     handleConfirmation(message) {

--- a/src/plugins/IOThrottling.js
+++ b/src/plugins/IOThrottling.js
@@ -151,7 +151,6 @@ module.exports = class IOThrottling extends OverlayPlugin {
         this.widget.appendChild(this.form);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
     }
 
@@ -185,23 +184,6 @@ module.exports = class IOThrottling extends OverlayPlugin {
         } else {
             this.readByteRateDiv.classList.add('gm-hidden');
         }
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/Identifiers.js
+++ b/src/plugins/Identifiers.js
@@ -135,25 +135,7 @@ module.exports = class Identifiers extends OverlayPlugin {
         this.widget.appendChild(this.container);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/KeyboardEvents.js
+++ b/src/plugins/KeyboardEvents.js
@@ -56,18 +56,12 @@ module.exports = class KeyboardEvents {
         this.instance.keyboardEvents = this;
         this.instance.keyboardEventsEnabled = true;
 
-        this.transmitKeys = true;
+        this.transmitKeys = this.instance.store.getState().isKeyboardEventsEnabled;
         this.isListenerAdded = false;
         this.currentlyPressedKeys = new Map();
 
-        // Listen for keyboard disable
-        this.instance.registerEventCallback('keyboard-disable', () => {
-            this.transmitKeys = false;
-        });
-
-        // Listen for keyboard enable
-        this.instance.registerEventCallback('keyboard-enable', () => {
-            this.transmitKeys = true;
+        this.instance.store.subscribe(({isKeyboardEventsEnabled}) => {
+            this.transmitKeys = isKeyboardEventsEnabled;
         });
     }
 

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -87,7 +87,9 @@ module.exports = class MouseEvents {
         }
         this.instance.sendEvent(json);
 
-        this.removeMouseUpListener();
+        if (this.removeMouseUpListener) {
+            this.removeMouseUpListener();
+        }
     }
 
     /**

--- a/src/plugins/Network.js
+++ b/src/plugins/Network.js
@@ -386,25 +386,7 @@ module.exports = class Network extends OverlayPlugin {
         this.widget.appendChild(this.form);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/Phone.js
+++ b/src/plugins/Phone.js
@@ -120,25 +120,7 @@ module.exports = class Phone extends OverlayPlugin {
         this.widget.appendChild(this.container);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
-    }
-
-    /**
-     * Display or hide the widget.
-     */
-    toggleWidget() {
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
     }
 
     /**

--- a/src/plugins/Screencast.js
+++ b/src/plugins/Screencast.js
@@ -279,7 +279,6 @@ module.exports = class Screencast extends OverlayPlugin {
         this.widget.appendChild(this.form);
 
         // Render into document
-        this.overlays.push(this.widget);
         this.instance.root.appendChild(this.widget);
     }
 
@@ -297,17 +296,7 @@ module.exports = class Screencast extends OverlayPlugin {
             return;
         }
 
-        // Notify other callers
-        if (this.widget.classList.contains('gm-hidden')) {
-            this.instance.emit('close-overlays');
-            this.instance.emit('keyboard-disable');
-        } else {
-            this.instance.emit('keyboard-enable');
-        }
-
-        // Toggle display
-        this.widget.classList.toggle('gm-hidden');
-        this.toolbarBtnImage.classList.toggle('gm-active');
+        super.toggleWidget();
 
         if (keepIconActive === true) {
             this.toolbarBtnImage.classList.add('gm-screencast-button-recording');

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,14 +1,26 @@
 'use strict';
 const {generateUID} = require('../utils/helpers');
+const log = require('loglevel');
+log.setDefaultLevel('debug');
 
 const initialState = {
     isWebRTCConnectionReady: false,
+    overlay: {
+        isOpen: false,
+        widgetOpened: [],
+    },
+    isKeyboardEventsEnabled: true,
 };
 
 const createStore = (instance, reducer, state) => {
     const listeners = [];
 
     const getState = () => instance.store.state;
+
+    const getters = {
+        isWidgetOpened: (overlayID) =>
+            instance.store.state.overlay.isOpen && instance.store.state.overlay.widgetOpened.includes(overlayID),
+    };
 
     const dispatch = (action) => {
         instance.store.state = reducer(instance.store.state, action);
@@ -34,13 +46,49 @@ const createStore = (instance, reducer, state) => {
         return unsubscribe;
     };
 
-    instance.store = {state, getState, dispatch, subscribe};
+    instance.store = {state, getState, dispatch, subscribe, getters};
 };
 
 const reducer = (state, action) => {
+    log.debug('Store updated', action.type, action.payload);
+
     switch (action.type) {
         case 'WEBRTC_CONNECTION_READY':
             return {...state, isWebRTCConnectionReady: action.payload};
+        case 'KEYBOARD_EVENTS_ENABLED':
+            return {...state, isKeyboardEventsEnabled: action.payload};
+        case 'OVERLAY_OPEN':
+            // eslint-disable-next-line no-case-declarations
+            const {overlayID, toOpen} = action.payload;
+            if (toOpen) {
+                return {
+                    ...state,
+                    overlay: {
+                        isOpen: true,
+                        widgetOpened: [overlayID],
+                        /*
+                         * to open several widgets at the same time
+                         * widgetOpened: [...state.overlay.widgetOpened, overlayID],
+                         */
+                    },
+                    isKeyboardEventsEnabled: false,
+                };
+            }
+            // eslint-disable-next-line no-case-declarations
+            const widgetOpened = [];
+            /*
+             *  to open several widgets at the same time
+             * const widgetOpened = state.overlay.widgetOpened.filter((widgetId) => widgetId !== overlayID);
+             */
+            return {
+                ...state,
+                overlay: {
+                    isOpen: widgetOpened.length > 0,
+                    widgetOpened,
+                },
+                isKeyboardEventsEnabled: true,
+            };
+
         default:
             return state;
     }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -3,8 +3,7 @@
 function generateUID() {
     const date = Date.now().toString(36);
     const part1 = date.substring(date.length - 5);
-    const part2 = Math.random().toString(36)
-        .substring(2, 7);
+    const part2 = Math.random().toString(36).substring(2, 7);
     return part1 + part2;
 }
 

--- a/src/worker/FileUploaderWorker.js
+++ b/src/worker/FileUploaderWorker.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function() {
+module.exports = function () {
     const self = this;
     this.socket = null;
     this.token = null;
@@ -11,7 +11,7 @@ module.exports = function() {
     this.address = null;
     this.MEGABYTE = 1000 * 1000;
 
-    self.getChunkSize = function(fileSize) {
+    self.getChunkSize = function (fileSize) {
         /*
          * The minimum upload size of chunk is 5MB.
          * If we are uploading a "big" file, we are uploading 10% by 10%.
@@ -22,7 +22,7 @@ module.exports = function() {
         return Math.max(minimum, Math.min(0.1 * fileSize, maximum));
     };
 
-    self.onOpen = function() {
+    self.onOpen = function () {
         const tokenRequest = {
             type: 'token',
             token: self.token,
@@ -30,13 +30,13 @@ module.exports = function() {
         self.socket.send(JSON.stringify(tokenRequest));
     };
 
-    self.onClose = function() {
-        setTimeout(function() {
+    self.onClose = function () {
+        setTimeout(function () {
             self.connect(self.address);
         }, 1000);
     };
 
-    self.connect = function(address) {
+    self.connect = function (address) {
         self.socket = new WebSocket(address);
         self.socket.binaryType = 'arraybuffer';
         self.socket.onopen = self.onOpen;
@@ -45,7 +45,7 @@ module.exports = function() {
         self.socket.onclose = self.onClose;
     };
 
-    self.onFailure = function() {
+    self.onFailure = function () {
         const msg = {
             type: 'FILE_UPLOAD',
             code: 'FAIL',
@@ -54,13 +54,13 @@ module.exports = function() {
         postMessage(msg);
     };
 
-    self.uploadData = function(event) {
+    self.uploadData = function (event) {
         if (self.hasError === false) {
             self.socket.send(event.target.result, {binary: true});
         }
     };
 
-    self.onSocketMsg = function(evt) {
+    self.onSocketMsg = function (evt) {
         const msg = JSON.parse(evt.data);
 
         if (msg.type === 'FILE_UPLOAD') {
@@ -108,7 +108,7 @@ module.exports = function() {
         }
     };
 
-    self.onmessage = function(event) {
+    self.onmessage = function (event) {
         const msg = event.data;
 
         switch (msg.type) {

--- a/tests/mocks/DeviceRenderer.js
+++ b/tests/mocks/DeviceRenderer.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Original = require('../../src/DeviceRenderer');
-
 module.exports = class DeviceRenderer extends Original {
     constructor(options) {
         document.body.innerHTML = `
@@ -38,6 +37,10 @@ module.exports = class DeviceRenderer extends Original {
                 return {};
             },
             subscribe: jest.fn(),
+            dispatch: jest.fn(),
+            getters: {
+                isWidgetOpened: () => false,
+            },
         };
         this.apiManager = {
             registerFunction: jest.fn(),

--- a/tests/unit/clipboard.test.js
+++ b/tests/unit/clipboard.test.js
@@ -4,6 +4,7 @@ jest.mock('loglevel');
 
 const Clipboard = require('../../src/plugins/Clipboard');
 const Instance = require('../mocks/DeviceRenderer');
+const store = require('../../src/store/index');
 
 let clipboard;
 let instance;
@@ -12,6 +13,7 @@ let plugin;
 describe('Clipboard Plugin', () => {
     beforeEach(() => {
         instance = new Instance();
+        store(instance);
         clipboard = new Clipboard(instance, {});
         plugin = document.getElementsByClassName('gm-clipboard-plugin')[0];
     });
@@ -25,6 +27,7 @@ describe('Clipboard Plugin', () => {
     describe('UI', () => {
         beforeEach(() => {
             instance = new Instance();
+            store(instance);
             clipboard = new Clipboard(instance, {
                 CLIPBOARD_TITLE: 'TEST CLIPBOARD PLUGIN TITLE',
             });

--- a/tests/unit/fileupload.test.js
+++ b/tests/unit/fileupload.test.js
@@ -1,7 +1,8 @@
 'use strict';
-
+jest.mock('loglevel');
 const FileUpload = require('../../src/plugins/FileUpload');
 const Instance = require('../mocks/DeviceRenderer');
+const store = require('../../src/store/index');
 
 let uploader;
 let instance;
@@ -10,6 +11,8 @@ let plugin;
 describe('FileUpload Plugin', () => {
     beforeEach(() => {
         instance = new Instance();
+        store(instance);
+
         uploader = new FileUpload(instance, {
             UPLOADER_INSTALLING: 'TEST UPLOADER PLUGIN INSTALLING...',
         });
@@ -31,6 +34,7 @@ describe('FileUpload Plugin', () => {
     describe('UI', () => {
         beforeEach(() => {
             instance = new Instance();
+            store(instance);
             uploader = new FileUpload(instance, {
                 UPLOADER_TITLE: 'TEST UPLOADER PLUGIN TITLE',
                 UPLOADER_HOME_TITLE: 'TEST UPLOADER PLUGIN HOME TITLE',


### PR DESCRIPTION
## Description

PR before adding keymapping plugin. The goal is to have a cleaner way to manage the keyboard status.

- Overlay have been refacto to be manage by store
- Keyboard key press enable / disable have been refacto to be manage by store
- some eslint on a separate commit


## Type of change

- [x] Refacto
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
- [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] I have made corresponding changes to the documentation (README.md).
- [ ] I've checked my modifications for any breaking changes.
