### PR TITLE
[PLAYER-25] adding api to track event

### DIFF
--- a/src/plugins/FileUpload.js
+++ b/src/plugins/FileUpload.js
@@ -277,6 +277,13 @@ module.exports = class FileUpload extends OverlayPlugin {
             textProgress.innerHTML = this.i18n.UPLOADER_INSTALLING || 'Installing...';
         } else if (data[0] === 'ready' && data.length >= 2) {
             if (data[1].indexOf('opengapps') !== -1) {
+                this.instance.store.dispatch({
+                    type: 'ADD_TRACKED_EVENT',
+                    payload: {
+                        category: 'opengapps',
+                        type: 'installed',
+                    },
+                });
                 this.updateOpenGAppsStatus(true);
             }
 

--- a/src/plugins/GamepadManager.js
+++ b/src/plugins/GamepadManager.js
@@ -262,6 +262,13 @@ module.exports = class GamepadManager {
      * @param {GamepadEvent} event raw event coming from the browser Gamepad API
      */
     onGamepadConnected(event) {
+        this.instance.store.dispatch({
+            type: 'ADD_TRACKED_EVENT',
+            payload: {
+                category: 'gamepad',
+                action: 'plugged',
+            },
+        });
         const customEvent = new CustomEvent('gm-gamepadConnected', {detail: this.parseGamepad(event.gamepad)});
         window.dispatchEvent(customEvent);
     }
@@ -271,6 +278,13 @@ module.exports = class GamepadManager {
      * @param {GamepadEvent} event raw event coming from the browser Gamepad API
      */
     onGamepadDisconnected(event) {
+        this.instance.store.dispatch({
+            type: 'ADD_TRACKED_EVENT',
+            payload: {
+                category: 'gamepad',
+                action: 'unplugged',
+            },
+        });
         const customEvent = new CustomEvent('gm-gamepadDisconnected', {detail: this.parseGamepad(event.gamepad)});
         window.dispatchEvent(customEvent);
         this.stopListeningInputs(event.gamepad.index);

--- a/src/plugins/KeyboardEvents.js
+++ b/src/plugins/KeyboardEvents.js
@@ -58,13 +58,16 @@ module.exports = class KeyboardEvents {
         this.isListenerAdded = false;
         this.currentlyPressedKeys = new Map();
 
-        this.instance.store.subscribe(({isKeyboardEventsEnabled}) => {
-            if (isKeyboardEventsEnabled) {
-                this.addKeyboardCallbacks();
-            } else {
-                this.removeKeyboardCallbacks();
-            }
-        });
+        this.instance.store.subscribe(
+            ({isKeyboardEventsEnabled}) => {
+                if (isKeyboardEventsEnabled) {
+                    this.addKeyboardCallbacks();
+                } else {
+                    this.removeKeyboardCallbacks();
+                }
+            },
+            ['isKeyboardEventsEnabled'],
+        );
 
         // activate the plugin listening
         this.instance.store.dispatch({type: 'KEYBOARD_EVENTS_ENABLED', payload: true});

--- a/src/plugins/KeyboardMapping.js
+++ b/src/plugins/KeyboardMapping.js
@@ -193,12 +193,16 @@ module.exports = class KeyboardMapping {
 
     activatePlugin() {
         if (this.state.isActive) {
-            this.toolbarBtnImage.classList.add('gm-active');
+            if (this.toolbarBtnImage) {
+                this.toolbarBtnImage.classList.add('gm-active');
+            }
             this.addKeyboardCallbacks();
             this.instance.store.dispatch({type: 'KEYBOARD_EVENTS_ENABLED', payload: false});
             this.instance.store.dispatch({type: 'MOUSE_EVENTS_ENABLED', payload: false});
         } else {
-            this.toolbarBtnImage.classList.remove('gm-active');
+            if (this.toolbarBtnImage) {
+                this.toolbarBtnImage.classList.remove('gm-active');
+            }
             this.removeKeyboardCallbacks();
             this.instance.store.dispatch({type: 'KEYBOARD_EVENTS_ENABLED', payload: !this.state.isPaused});
             this.instance.store.dispatch({type: 'MOUSE_EVENTS_ENABLED', payload: !this.state.isPaused});

--- a/src/plugins/KeyboardMapping.js
+++ b/src/plugins/KeyboardMapping.js
@@ -157,13 +157,16 @@ module.exports = class KeyboardMapping {
         );
 
         // pause the listeners when dialog is open and plugin isActive
-        this.instance.store.subscribe(({overlay: {isOpen}}) => {
-            if (isOpen && this.state.isActive) {
-                this.state.isPaused = true;
-            } else if (!isOpen && this.state.isPaused) {
-                this.state.isPaused = false;
-            }
-        });
+        this.instance.store.subscribe(
+            ({overlay: {isOpen}}) => {
+                if (isOpen && this.state.isActive) {
+                    this.state.isPaused = true;
+                } else if (!isOpen && this.state.isPaused) {
+                    this.state.isPaused = false;
+                }
+            },
+            ['overlay.isOpen'],
+        );
 
         // Display widget
         this.renderToolbarButton();

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -22,13 +22,16 @@ module.exports = class MouseEvents {
         this.boundEventListener = this.releaseAtPreviousPositionEvent.bind(this);
         this.removeMouseUpListener = () => {};
 
-        this.instance.store.subscribe(({isMouseEventsEnabled}) => {
-            if (isMouseEventsEnabled) {
-                this.addMouseCallbacks();
-            } else {
-                this.removeMouseCallbacks();
-            }
-        });
+        this.instance.store.subscribe(
+            ({isMouseEventsEnabled}) => {
+                if (isMouseEventsEnabled) {
+                    this.addMouseCallbacks();
+                } else {
+                    this.removeMouseCallbacks();
+                }
+            },
+            ['isMouseEventsEnabled'],
+        );
 
         this.mouseCallbacks = [];
 

--- a/src/plugins/util/OverlayPlugin.js
+++ b/src/plugins/util/OverlayPlugin.js
@@ -19,13 +19,16 @@ class OverlayPlugin {
         this.instance = instance;
 
         // Listen for close trigger
-        this.instance.store.subscribe(({overlay}) => {
-            if (overlay.widgetOpened.includes(this.overlayID)) {
-                this.openOverlay();
-            } else {
-                this.closeOverlay();
-            }
-        });
+        this.instance.store.subscribe(
+            ({overlay}) => {
+                if (overlay.widgetOpened.includes(this.overlayID)) {
+                    this.openOverlay();
+                } else {
+                    this.closeOverlay();
+                }
+            },
+            ['overlay.widgetOpened'],
+        );
 
         // Attach listener for first object created only
         if (!OverlayPlugin.hasBeenCalled) {

--- a/src/plugins/util/OverlayPlugin.js
+++ b/src/plugins/util/OverlayPlugin.js
@@ -61,6 +61,14 @@ class OverlayPlugin {
         if (this.toolbarBtnImage) {
             this.toolbarBtnImage.classList.add('gm-active');
         }
+        this.instance.store.dispatch({
+            type: 'ADD_TRACKED_EVENT',
+            payload: {
+                category: 'widget',
+                action: 'open',
+                name: this.constructor.name,
+            },
+        });
     }
 
     /**

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -33,31 +33,31 @@ const createStore = (instance, reducer) => {
         });
     };
 
-    const arraysAreEqual = (firstArray, secondArray) => {
-        if (firstArray.length !== secondArray.length) {
-            return true;
-        }
-        for (let i = 0; i < firstArray.length; i++) {
-            if (firstArray[i] !== secondArray[i]) {
-                return true;
-            }
-        }
-        return false;
-    };
     const findChangedKeys = (newState, oldState, path = []) => {
         let changedKeys = [];
+
         const isObject = (obj) => obj && typeof obj === 'object';
+
         for (const key in newState) {
             const fullPath = [...path, key].join('.');
+
             if (!Object.prototype.hasOwnProperty.call(oldState, key)) {
                 changedKeys.push(fullPath);
             } else if (isObject(newState[key]) && isObject(oldState[key])) {
-                if (
-                    Array.isArray(newState[key]) &&
-                    Array.isArray(oldState[key]) &&
-                    !arraysAreEqual(newState[key], oldState[key])
-                ) {
-                    changedKeys.push(fullPath);
+                if (Array.isArray(newState[key]) && Array.isArray(oldState[key])) {
+                    if (newState[key].length !== oldState[key].length) {
+                        changedKeys.push(fullPath);
+                    } else {
+                        let arrayHasChanged = false;
+                        for (let i = 0; i < newState[key].length; i++) {
+                            if (newState[key][i] !== oldState[key][i]) {
+                                arrayHasChanged = true;
+                            }
+                        }
+                        if (arrayHasChanged) {
+                            changedKeys.push(fullPath);
+                        }
+                    }
                 } else {
                     changedKeys = changedKeys.concat(findChangedKeys(newState[key], oldState[key], [...path, key]));
                 }
@@ -65,6 +65,7 @@ const createStore = (instance, reducer) => {
                 changedKeys.push(fullPath);
             }
         }
+
         return changedKeys;
     };
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -13,7 +13,7 @@ const initialState = {
     isMouseEventsEnabled: false,
 };
 
-const createStore = (instance, reducer, state) => {
+const createStore = (instance, reducer) => {
     const listeners = [];
 
     const getters = {
@@ -21,18 +21,71 @@ const createStore = (instance, reducer, state) => {
             instance.store.state.overlay.isOpen && instance.store.state.overlay.widgetOpened.includes(overlayID),
     };
 
-    const dispatch = (action) => {
-        instance.store.state = reducer(instance.store.state, action);
-        listeners.forEach(({cb}) => {
-            cb();
+    const hasChanged = (changedKeys, keyPath) => {
+        const keys = keyPath.split('.');
+        return changedKeys.some((changedKey) => {
+            const changedKeyParts = changedKey.split('.');
+            return keys.every((key, index) => key === changedKeyParts[index]);
         });
     };
 
-    const subscribe = (listener) => {
+    const findChangedKeys = (newState, oldState, path = []) => {
+        let changedKeys = [];
+
+        const isObject = (obj) => obj && typeof obj === 'object';
+
+        for (const key in newState) {
+            const fullPath = [...path, key].join('.');
+
+            if (!Object.prototype.hasOwnProperty.call(oldState, key)) {
+                changedKeys.push(fullPath);
+            } else if (isObject(newState[key]) && isObject(oldState[key])) {
+                if (Array.isArray(newState[key]) && Array.isArray(oldState[key])) {
+                    if (newState[key].length !== oldState[key].length) {
+                        changedKeys.push(fullPath);
+                    } else {
+                        let arrayHasChanged = false;
+                        for (let i = 0; i < newState[key].length; i++) {
+                            if (newState[key][i] !== oldState[key][i]) {
+                                arrayHasChanged = true;
+                            }
+                        }
+                        if (arrayHasChanged) {
+                            changedKeys.push(fullPath);
+                        }
+                    }
+                } else {
+                    changedKeys = changedKeys.concat(findChangedKeys(newState[key], oldState[key], [...path, key]));
+                }
+            } else if (newState[key] !== oldState[key]) {
+                changedKeys.push(fullPath);
+            }
+        }
+
+        return changedKeys;
+    };
+
+    const notifyListeners = (changedKeys) => {
+        listeners.forEach(({keys, cb}) => {
+            if (keys.length === 0 || keys.some((key) => hasChanged(changedKeys, key))) {
+                cb(instance.store.state);
+            }
+        });
+    };
+
+    const dispatch = (action) => {
+        const previousState = JSON.parse(JSON.stringify(instance.store.state));
+        instance.store.state = reducer({...instance.store.state}, action);
+        const changedKeys = findChangedKeys(instance.store.state, previousState);
+        notifyListeners(changedKeys);
+    };
+
+    const subscribe = (listener, keys = []) => {
         const uid = generateUID();
         listeners.push({
             uid,
-            cb: () => listener(instance.store.state),
+            keys,
+            cb: listener,
         });
 
         const unsubscribe = () => {
@@ -45,68 +98,51 @@ const createStore = (instance, reducer, state) => {
         return unsubscribe;
     };
 
-    instance.store = {state, dispatch, subscribe, getters};
+    instance.store = {state: initialState, dispatch, subscribe, getters};
 };
 
 const reducer = (state, action) => {
-    let newState = state;
     switch (action.type) {
         case 'WEBRTC_CONNECTION_READY':
-            newState = {...state, isWebRTCConnectionReady: action.payload};
+            state.isWebRTCConnectionReady = action.payload;
             break;
         case 'KEYBOARD_EVENTS_ENABLED':
-            newState = {...state, isKeyboardEventsEnabled: action.payload};
+            state.isKeyboardEventsEnabled = action.payload;
             break;
         case 'MOUSE_EVENTS_ENABLED':
-            newState = {...state, isMouseEventsEnabled: action.payload};
+            state.isMouseEventsEnabled = action.payload;
             break;
         case 'OVERLAY_OPEN':
             // eslint-disable-next-line no-case-declarations
             const {overlayID, toOpen} = action.payload;
             if (toOpen) {
-                newState = {
-                    ...state,
-                    overlay: {
-                        isOpen: true,
-                        widgetOpened: [overlayID],
-                        /*
-                         * to open several widgets at the same time
-                         * widgetOpened: [...state.overlay.widgetOpened, overlayID],
-                         */
-                    },
-                    isKeyboardEventsEnabled: false,
-                    isMouseEventsEnabled: false,
-                };
-                break;
+                state.overlay.isOpen = true;
+                /*
+                 * to open several widgets at the same time
+                 * widgetOpened: [...state.overlay.widgetOpened, overlayID],
+                 */
+                state.overlay.widgetOpened = [overlayID];
+                state.isKeyboardEventsEnabled = false;
+                state.isMouseEventsEnabled = false;
+            } else {
+                state.overlay.isOpen = false;
+                state.overlay.widgetOpened = [];
+                state.isKeyboardEventsEnabled = true;
+                state.isMouseEventsEnabled = true;
             }
-            // eslint-disable-next-line no-case-declarations
-            const widgetOpened = [];
-            /*
-             *  to open several widgets at the same time
-             * const widgetOpened = state.overlay.widgetOpened.filter((widgetId) => widgetId !== overlayID);
-             */
-            newState = {
-                ...state,
-                overlay: {
-                    isOpen: widgetOpened.length > 0,
-                    widgetOpened,
-                },
-                isKeyboardEventsEnabled: true,
-                isMouseEventsEnabled: true,
-            };
             break;
         default:
             log.debug('Store not updated, action type :', action.type, ' unknown');
             break;
     }
 
-    log.debug('Store updated below type - payload - result', action.type, action.payload, newState);
+    log.debug('Store updated below type - payload - result', action.type, action.payload, state);
 
-    return newState;
+    return state;
 };
 
 const store = (instance) => {
-    createStore(instance, reducer, initialState);
+    createStore(instance, reducer);
 };
 
 module.exports = store;

--- a/tests/unit/apiManager.test.js
+++ b/tests/unit/apiManager.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const ApiManager = require('../../src/APIManager');
+const Instance = require('../mocks/DeviceRenderer');
+const Clipboard = require('../../src/plugins/Clipboard');
+const store = require('../../src/store/index');
+
+let apiManager;
+let instance;
+let exposedApiFunctions;
+
+describe('APIManager', () => {
+    beforeEach(() => {
+        instance = new Instance({});
+        apiManager = new ApiManager(instance);
+        exposedApiFunctions = apiManager.getExposedApiFunctions();
+        store(instance);
+
+        new Clipboard(instance, {
+            CLIPBOARD_TITLE: 'TEST CLIPBOARD PLUGIN TITLE',
+        });
+    });
+
+    describe('has exposed api', () => {
+        test('getRegisteredFunctions', () => {
+            const registeredFunctions = exposedApiFunctions.utils.getRegisteredFunctions();
+            expect(Object.keys(registeredFunctions)).toEqual(
+                expect.arrayContaining([
+                    'sendData',
+                    'getRegisteredFunctions',
+                    'addEventListener',
+                    'disconnect',
+                    'enableTrackEvents',
+                    'trackEvents',
+                ]),
+            );
+        });
+
+        test('sendTrackEvent', () => {
+            let events = [];
+
+            exposedApiFunctions.analytics.enableTrackEvents(true);
+
+            // attach callback to get events
+            exposedApiFunctions.analytics.trackEvents((evts) => {
+                events = evts;
+            });
+
+            const button = document.getElementsByClassName('gm-clipboard-button')[0];
+            expect(button).toBeTruthy();
+            button.click();
+
+            // expect object to be exactly the same
+            expect(events).toEqual([{category: 'widget', action: 'open', name: 'Clipboard'}]);
+        });
+    });
+});


### PR DESCRIPTION
## Description

### Store
Refacto store to subscribe only part of store change. Most likely React useEffect hook, we can now supply an array of dependencies. If no array is supply then the callback will be trigger on each store change

**this callback will be trigger only on isKeyboardEventsEnabled change**
```
   this.instance.store.subscribe(
            ({isKeyboardEventsEnabled}) => {
                ...
            },
            ['isKeyboardEventsEnabled'],
        );
```

**nested object**
```
   this.instance.store.subscribe(
            ({isKeyboardEventsEnabled}) => {
                ...
            },
            ['overlay.widgetOpened'],
        );
```

**Trigger on all change**
```
   this.instance.store.subscribe(
            ({isKeyboardEventsEnabled}) => {
                ...
            }
        );
```

### new feature
Adding functions to ApiManager to track events

Events currently tracked

- opengapps installed
- gamepad plug / unplug
- widget opened / closed

## Type of change

-   [x] New feature (non-breaking change which adds functionality)


## Checklist

-   [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
-   [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
-   [ ] I have made corresponding changes to the documentation (README.md).
-   [x] I've checked my modifications for any breaking changes.
