### PR TITLE
[PLAYER-35] change add event listener in apimanager

### DIFF
--- a/src/APIManager.js
+++ b/src/APIManager.js
@@ -22,7 +22,7 @@ module.exports = class APIManager {
             name: 'addEventListener',
             category: 'VM_communication',
             fn: (event, fn) => {
-                return this.instance.addEventListener(event, fn);
+                return this.instance.registerEventCallback(event, fn);
             },
             description:
                 // eslint-disable-next-line max-len

--- a/src/APIManager.js
+++ b/src/APIManager.js
@@ -34,7 +34,7 @@ module.exports = class APIManager {
             name: 'disconnect',
             category: 'VM_communication',
             fn: () => {
-                this.instance.disconnect();
+                this.instance.destroy();
             },
             description: 'Disconnect from the current instance, ending the WebSocket communication.',
         });

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -241,9 +241,13 @@ module.exports = class DeviceRenderer {
      * This will poll the WebRTC sequence until the WebSocket stops throwing the onclose event (unexpected quit).
      */
     onConnectionClosed() {
+        // closure to expose the right video and store context to onclose event
+        const video = this.video;
+        const store = this.store;
+
         this.webRTCWebsocket.onclose = (event) => {
-            this.store.dispatch({type: 'WEBRTC_CONNECTION_READY', payload: false});
-            this.video.style.background = this.videoBackupStyleBackground;
+            store.dispatch({type: 'WEBRTC_CONNECTION_READY', payload: false});
+            video.style.background = this.videoBackupStyleBackground;
             this.initialized = false;
             log.debug('Error! Maybe your VM is not available yet? (' + event.code + ') ' + event.reason);
 

--- a/src/plugins/GamepadManager.js
+++ b/src/plugins/GamepadManager.js
@@ -278,13 +278,6 @@ module.exports = class GamepadManager {
      * @param {GamepadEvent} event raw event coming from the browser Gamepad API
      */
     onGamepadDisconnected(event) {
-        this.instance.store.dispatch({
-            type: 'ADD_TRACKED_EVENT',
-            payload: {
-                category: 'gamepad',
-                action: 'unplugged',
-            },
-        });
         const customEvent = new CustomEvent('gm-gamepadDisconnected', {detail: this.parseGamepad(event.gamepad)});
         window.dispatchEvent(customEvent);
         this.stopListeningInputs(event.gamepad.index);


### PR DESCRIPTION
## Description

This PR have several fix

- replace exposed API addEventlistener by the dedicated registerEventCallback function
- added closure on this.video for onConnectionClosed function? This way if we connect the VD more than 1 time this.video isn't undefined anymore
- remove gamepad unplug tracked event