### PR TITLE
[PLAYER-31] fix wrong calculation border with css scale rule

### DIFF
--- a/src/plugins/KeyboardMapping.js
+++ b/src/plugins/KeyboardMapping.js
@@ -724,7 +724,14 @@ module.exports = class KeyboardMapping {
         if (isActive) {
             const parentSize = this.instance.videoWrapper.getBoundingClientRect();
             const videoSize = this.instance.video.getBoundingClientRect();
-            videoSize.height = videoSize.height - this.instance.coordinateUtils.getTopBorder() * 2;
+
+            if (!this.instance.coordinateUtils.hasLeftAndRightBorders()) {
+                // landscape: border top
+                videoSize.height = (this.instance.video.videoHeight / this.instance.video.videoWidth) * videoSize.width;
+            } else {
+                // portrait: border left
+                videoSize.width = (this.instance.video.videoWidth / this.instance.video.videoHeight) * videoSize.height;
+            }
 
             // div vertical
             Array.from(Array(11).keys()).forEach((val, i) => {


### PR DESCRIPTION
## Description

When a css rules (i.e. scale) is set on the player's HTML element the calculation of borders is wrong. This is caused by the offset's browser api which doesn't take css rules in this calculation

- change way of borders are calculated
- fix bug on keymapping debug grids for portrait