### PR TITLE
[PLAYER-38] change HTML  parent element of mouseevent listener plugin

### DIFF
--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -195,7 +195,7 @@ module.exports = class MouseEvents {
 
             this.mouseCallbacks.forEach((item, index, array) => {
                 array[index].removeListener = this.instance.addListener(
-                    this.instance.root,
+                    this.instance.videoWrapper,
                     item.event,
                     item.handler,
                     item.options,


### PR DESCRIPTION
## Description

fix bug when clicking on the icon of the resolution plugin, the selectbox wasn't displayed

Element of the listener wasn't correct