### PR TITLE
[PLAYER-30] remplace the key 'keys' to 'key' for keympapping tap et swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,67 +169,85 @@ sendData({
 ### `keymapping`
 
 -   #### `setConfig`
+
     supply a config for keymapping
+
     ```js
     {
-        dpad:[{
-            keys: {
-                z: {
-                    initialX: 20,
-                    initialY: 80,
-                    distanceX: 0,
-                    distanceY: -10,
+        dPad:[{
+            keys:[
+                {
+                    key: 'w',
+                    effect: {
+                        initialX: 20,
+                        initialY: 80,
+                        distanceX: 0,
+                        distanceY: -10,
+                    },
+                    name: 'up',
                     description: 'move up',
                 },
-                s: {
-                    initialX: 20,
-                    initialY: 80,
-                    distanceX: 0,
-                    distanceY: 10,
+                {
+                    key: 's',
+                    effect: {
+                        initialX: 20,
+                        initialY: 80,
+                        distanceX: 0,
+                        distanceY: 10,
+                    },
+                    name: 'down',
                     description: 'move down',
                 },
-                q: {
-                    initialX: 20,
-                    initialY: 80,
-                    distanceX: -10,
-                    distanceY: 0,
+                {
+                    key: 'a',
+                    effect: {
+                        initialX: 20,
+                        initialY: 80,
+                        distanceX: -10,
+                        distanceY: 0,
+                    },
+                    name: 'left',
                     description: 'move left',
                 },
-                d: {
-                    initialX: 20,
-                    initialY: 80,
-                    distanceX: 10,
-                    distanceY: 0,
+                {
+                    key: 'd',
+                    effect: {
+                        initialX: 20,
+                        initialY: 80,
+                        distanceX: 10,
+                        distanceY: 0,
+                    },
+                    name: 'up',
                     description: 'move right',
                 },
-            },
+
+            ],
             name: 'character movement',
             description: 'left joystick used to move the character',
         }],
         tap:[{
-            key: {
-                p: {
-                    initialX: 50,
-                    initialY: 50,
-                },
-            }
+            key: 'p',
+            effect: {
+                initialX: 50,
+                initialY: 50,
+            },
             name:'Fire'
         }],
         swipe: [{
-            key: {
-                u: {
-                    initialX: 50,
-                    initialY: 50,
-                    distanceX: -10,
-                    distanceY: 0,
-                    description: 'swipe left',
-                },
-            }
-            name:'Left dodge'
+            key: 'u',
+            effect: {
+                initialX: 50,
+                initialY: 50,
+                distanceX: -10,
+                distanceY: 0,
+                description: 'swipe left',
+            },
+            name:'Left dodge',
             description: 'Dodge on the left'
         }]
     }
     ```
+
 -   #### `activeKeyMappingDebug`
 
     helper to create the config mapping

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ sendData({
             description: 'left joystick used to move the character',
         }],
         tap:[{
-            keys: {
+            key: {
                 p: {
                     initialX: 50,
                     initialY: 50,
@@ -216,7 +216,7 @@ sendData({
             name:'Fire'
         }],
         swipe: [{
-            keys: {
+            key: {
                 u: {
                     initialX: 50,
                     initialY: 50,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,157 +1,165 @@
 type KeyEffectDistance = {
-  distanceX: number;
-  distanceY: number;
+    distanceX: number;
+    distanceY: number;
 };
 
 interface KeyEffect {
-  initialX: number;
-  initialY: number;
-  name?: string;
-  description?: string;
+    initialX: number;
+    initialY: number;
+    name?: string;
+    description?: string;
 }
 
-interface KeyMap<E> {
-  keys: Record<string, E>;
-  name?: string;
-  description?: string;
+interface KeysMap<E> {
+    keys: Record<string, E>;
+    name?: string;
+    description?: string;
+}
+
+interface Key<E> {
+    key: string;
+    effect: E;
+    name?: string;
+    description?: string;
 }
 
 interface KeyMappingConfig {
-  dpad?: KeyMap<KeyEffect & KeyEffectDistance>[];
-  tap?: KeyMap<KeyEffect>[];
-  swipe?: KeyMap<KeyEffect & KeyEffectDistance>[];
+    dpad?: KeysMap<KeyEffect & KeyEffectDistance>[];
+    tap?: Key<KeyEffect>[];
+    swipe?: Key<KeyEffect & KeyEffectDistance>[];
 }
 
 type DeviceRendererKeyMapping = {
-  enable(isEnable: boolean): void;
-  setConfig(config: KeyMappingConfig): void;
-  activeKeyMappingDebug(isTraceActivate?: boolean, isGridActivate?: boolean): void;
+    enable(isEnable: boolean): void;
+    setConfig(config: KeyMappingConfig): void;
+    activeKeyMappingDebug(isTraceActivate?: boolean, isGridActivate?: boolean): void;
 };
 
 type VmEvent =
-  | 'ANDROID_ID'
-  | 'baseband'
-  | 'BATTERY_LEVEL'
-  | 'BATTERY_STATUS'
-  | 'battery'
-  | 'beforeunload'
-  | 'BLK'
-  | 'CLIPBOARD'
-  | 'diskio'
-  | 'fingerprint'
-  | 'framework'
-  | 'gps'
-  | 'IMEI'
-  | 'network_profile'
-  | 'NETWORK'
-  | 'settings'
-  | 'SYSTEM_PATCHER_LAST_RESULT'
-  | 'SYSTEM_PATCHER_STATUS'
-  | 'systempatcher'
-  | 'vinput'
-  | string // This list is not exhaustive and should be completed
+    | 'ANDROID_ID'
+    | 'baseband'
+    | 'BATTERY_LEVEL'
+    | 'BATTERY_STATUS'
+    | 'battery'
+    | 'beforeunload'
+    | 'BLK'
+    | 'CLIPBOARD'
+    | 'diskio'
+    | 'fingerprint'
+    | 'framework'
+    | 'gps'
+    | 'IMEI'
+    | 'network_profile'
+    | 'NETWORK'
+    | 'settings'
+    | 'SYSTEM_PATCHER_LAST_RESULT'
+    | 'SYSTEM_PATCHER_STATUS'
+    | 'systempatcher'
+    | 'vinput'
+    | string; // This list is not exhaustive and should be completed
 
 type VmCommunication = {
-  disconnect(): void;
-  addEventListener(event: VmEvent, callback: (msg: string) => void): void;
-  sendData(data: { channel: string; messages: string[] }): void;
+    disconnect(): void;
+    addEventListener(event: VmEvent, callback: (msg: string) => void): void;
+    sendData(data: {channel: string; messages: string[]}): void;
 };
 
 type RegisteredFunctionDoc = {
-  apiName: string,
-  apiDescription: string,
-}
+    apiName: string;
+    apiDescription: string;
+};
 
 type Utils = {
-  getRegisteredFunctions(): RegisteredFunctionDoc[];
+    getRegisteredFunctions(): RegisteredFunctionDoc[];
 };
 
 type Media = {
-  mute(): void;
-  unmute(): void;
+    mute(): void;
+    unmute(): void;
 };
 
 type Video = {
-  fullscreen: () => void;
+    fullscreen: () => void;
 };
 
-type Template = 'bootstrap'
-  | 'fullscreen'
-  | 'fullwindow'
-  | 'renderer'
-  | 'renderer_minimal'
-  | 'renderer_no_toolbar'
-  | 'renderer_partial';
+type Template =
+    | 'bootstrap'
+    | 'fullscreen'
+    | 'fullwindow'
+    | 'renderer'
+    | 'renderer_minimal'
+    | 'renderer_no_toolbar'
+    | 'renderer_partial';
 
 interface RendererSetupOptions {
-  baseband?: boolean; // Default: false
-  battery?: boolean; // Default: true
-  biometrics?: boolean; // Default: true
-  camera?: boolean; // Default: true
-  capture?: boolean; // Default: true
-  clipboard?: boolean; // Default: true
-  connectionFailedURL?: string;
-  diskIO?: boolean; // Default: true
-  fileUpload?: boolean; // Default: true
-  fileUploadUrl?: string;
-  fullscreen?: boolean; // Default: true
-  gamepad?: boolean; // Default: true
-  giveFeedbackLink?: string;
-  gps?: boolean; // Default: true
-  gpsSpeedSupport?: boolean; // Default: false
-  i18n?: Record<string, string>;
-  identifiers?: boolean; // Default: true
-  keyboard?: boolean; // Default: true
-  keyboardMapping?: boolean; // Default: true
-  microphone?: boolean; // Default: false
-  mobilethrottling?: boolean; // Default: false
-  mouse?: boolean; // Default: true
-  navbar?: boolean; // Default: true
-  network?: boolean; // Default: true
-  phone?: boolean; // Default: true
-  power?: boolean; // Default: true
-  rotation?: boolean; // Default: true
-  streamBitrate?: boolean; // Default: false
-  streamResolution?: boolean; // Default: true
-  stun?: { urls?: string[] };
-  template?: Template; // Default: 'renderer'
-  token?: string;
-  touch?: boolean; // Default: true
-  translateHomeKey?: boolean; // Default: false
-  turn?: {
-    urls?: string[];
-    username?: string;
-    credential?: string;
-    default?: boolean; // Default: false
-  };
-  volume?: boolean; // Default: true
+    baseband?: boolean; // Default: false
+    battery?: boolean; // Default: true
+    biometrics?: boolean; // Default: true
+    camera?: boolean; // Default: true
+    capture?: boolean; // Default: true
+    clipboard?: boolean; // Default: true
+    connectionFailedURL?: string;
+    diskIO?: boolean; // Default: true
+    fileUpload?: boolean; // Default: true
+    fileUploadUrl?: string;
+    fullscreen?: boolean; // Default: true
+    gamepad?: boolean; // Default: true
+    giveFeedbackLink?: string;
+    gps?: boolean; // Default: true
+    gpsSpeedSupport?: boolean; // Default: false
+    i18n?: Record<string, string>;
+    identifiers?: boolean; // Default: true
+    keyboard?: boolean; // Default: true
+    keyboardMapping?: boolean; // Default: true
+    microphone?: boolean; // Default: false
+    mobilethrottling?: boolean; // Default: false
+    mouse?: boolean; // Default: true
+    navbar?: boolean; // Default: true
+    network?: boolean; // Default: true
+    phone?: boolean; // Default: true
+    power?: boolean; // Default: true
+    rotation?: boolean; // Default: true
+    streamBitrate?: boolean; // Default: false
+    streamResolution?: boolean; // Default: true
+    stun?: {urls?: string[]};
+    template?: Template; // Default: 'renderer'
+    token?: string;
+    touch?: boolean; // Default: true
+    translateHomeKey?: boolean; // Default: false
+    turn?: {
+        urls?: string[];
+        username?: string;
+        credential?: string;
+        default?: boolean; // Default: false
+    };
+    volume?: boolean; // Default: true
 }
 
 type DefaultTrue<B, T> = B extends void
-? T // Key is not present
-: B extends true | undefined
-  ? T // Key is true or undefined
-  : B extends false
-    ? undefined // Key is false
-    : T | undefined; // Key is true, false or undefined (we cannot infer anything)
+    ? T // Key is not present
+    : B extends true | undefined
+      ? T // Key is true or undefined
+      : B extends false
+        ? undefined // Key is false
+        : T | undefined; // Key is true, false or undefined (we cannot infer anything)
 
-type ExtractKey<O, K extends keyof O> = O extends { [P in K]: infer T } ? T : void;
+type ExtractKey<O, K extends keyof O> = O extends {[P in K]: infer T} ? T : void;
 
 type DeviceRendererApi<O extends RendererSetupOptions = RendererSetupOptions> = {
-  keyMapping: DefaultTrue<ExtractKey<O, 'keyboardMapping'>, DeviceRendererKeyMapping>;
-  media: Media;
-  utils: Utils;
-  video?: Video; // Available if any plugin (e.g. fullscreen) using it is enabled.
-  VM_communication: VmCommunication;
+    keyMapping: DefaultTrue<ExtractKey<O, 'keyboardMapping'>, DeviceRendererKeyMapping>;
+    media: Media;
+    utils: Utils;
+    video?: Video; // Available if any plugin (e.g. fullscreen) using it is enabled.
+    VM_communication: VmCommunication;
 };
 
 declare class DeviceRendererFactory {
-  constructor();
-  setupRenderer<O extends RendererSetupOptions>(
-    targetElement: HTMLDivElement,
-    webrtcAddress: string,
-    options?: O,
-  ): DeviceRendererApi<O>;
+    constructor();
+    setupRenderer<O extends RendererSetupOptions>(
+        targetElement: HTMLDivElement,
+        webrtcAddress: string,
+        options?: O,
+    ): DeviceRendererApi<O>;
 }
 
-export { DeviceRendererApi, DeviceRendererFactory, RendererSetupOptions, KeyMappingConfig }
+export {DeviceRendererApi, DeviceRendererFactory, RendererSetupOptions, KeyMappingConfig};

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,8 +10,8 @@ interface KeyEffect {
     description?: string;
 }
 
-interface KeysMap<E> {
-    keys: Record<string, E>;
+interface KeyList<E> {
+    keys: Key<E>[];
     name?: string;
     description?: string;
 }
@@ -24,7 +24,7 @@ interface Key<E> {
 }
 
 interface KeyMappingConfig {
-    dpad?: KeysMap<KeyEffect & KeyEffectDistance>[];
+    dpad?: KeyList<KeyEffect & KeyEffectDistance>[];
     tap?: Key<KeyEffect>[];
     swipe?: Key<KeyEffect & KeyEffectDistance>[];
 }

--- a/src/plugins/KeyboardMapping.js
+++ b/src/plugins/KeyboardMapping.js
@@ -225,7 +225,8 @@ module.exports = class KeyboardMapping {
             gestureConfig.forEach((gesture) => {
                 const groupId = generateUID();
                 this.sequences[groupId] = [];
-                Object.entries(gesture.keys).forEach(([key, value]) => {
+                const keyName = gestureType === 'dPad' ? 'keys' : 'key';
+                Object.entries(gesture[keyName]).forEach(([key, value]) => {
                     this.state.workingMappedKeysConfig[key] = {
                         ...value,
                         key,

--- a/src/plugins/KeyboardMapping.js
+++ b/src/plugins/KeyboardMapping.js
@@ -225,11 +225,11 @@ module.exports = class KeyboardMapping {
             gestureConfig.forEach((gesture) => {
                 const groupId = generateUID();
                 this.sequences[groupId] = [];
-                const keyName = gestureType === 'dPad' ? 'keys' : 'key';
-                Object.entries(gesture[keyName]).forEach(([key, value]) => {
-                    this.state.workingMappedKeysConfig[key] = {
-                        ...value,
-                        key,
+                const gestureObject = gestureType === 'dPad' ? gesture.keys : gestureConfig;
+                Object.values(gestureObject).forEach((value) => {
+                    this.state.workingMappedKeysConfig[value.key] = {
+                        ...value.effect,
+                        key: value.key,
                         type: gestureType,
                         name: gesture.name,
                         groupId,
@@ -342,8 +342,8 @@ module.exports = class KeyboardMapping {
 
     generateTouchSequence(key) {
         const groupId = this.state.workingMappedKeysConfig[key].groupId;
-        const x = this.state.workingMappedKeysConfig[key].x;
-        const y = this.state.workingMappedKeysConfig[key].y;
+        const x = this.state.workingMappedKeysConfig[key].initialX;
+        const y = this.state.workingMappedKeysConfig[key].initialY;
 
         this.sequences[groupId].push({
             type: 'MULTI_TOUCH',


### PR DESCRIPTION
## Description

replace the key named keys to 'key' for tap and swipe in the json config

update json keymapping config.

```
TYPE:[{
        keys: {
            p: {
                initialX: 50,
                initialY: 50,
            },
        }
        name:'Fire'
    }],
```

to


```
dPad:[{
        keys: {
            key: 'p',
            effect: {
                initialX: 50,
                initialY: 50,
            },
        }
        name:'Fire'
    }],
tap:[{
         key: 'p',
         effect: {
             initialX: 50,
             initialY: 50,
         },
         name:'Fire'
    }],
```