### PR TITLE
replace way of check if plugin charged

### DIFF
--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -151,7 +151,7 @@ module.exports = class DeviceRendererFactory {
 
         this.instances.push(instance);
 
-        this.addPlugins(instance);
+        this.loadPlugins(instance);
         instance.onWebRTCReady();
 
         return instance.apiManager.getExposedApiFunctions();
@@ -195,7 +195,7 @@ module.exports = class DeviceRendererFactory {
      * @param  {DeviceRenderer}     instance The DeviceRenderer instance reference to link into each plugin.
      * @param  {Object}             options  Various configuration options.
      */
-    addPlugins(instance) {
+    loadPlugins(instance) {
         /*
          * Load instance dedicated plugins
          */
@@ -209,7 +209,7 @@ module.exports = class DeviceRendererFactory {
             }
         }
 
-        const dependenciesLoaded = [];
+        const dependenciesLoaded = new Map();
         pluginInitMap.forEach((plugin) => {
             const args = plugin.params || [];
 
@@ -217,11 +217,12 @@ module.exports = class DeviceRendererFactory {
                 // load dependencies
                 if (plugin.dependencies) {
                     plugin.dependencies.forEach((Dep) => {
-                        if (dependenciesLoaded.indexOf(Dep.name) !== -1) {
+                        if (dependenciesLoaded.has(Dep)) {
                             return;
                         }
+
                         new Dep(instance);
-                        dependenciesLoaded.push(Dep.name);
+                        dependenciesLoaded.set(Dep, true);
                     });
                 }
                 // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
## Description

When player is used in third party app class.name could be empty in case of uglify process on node modules

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
