### PR TITLE
adding static get name on the plugins class

### DIFF
--- a/src/plugins/BasebandRIL.js
+++ b/src/plugins/BasebandRIL.js
@@ -7,6 +7,9 @@ const OverlayPlugin = require('./util/OverlayPlugin');
  * Provides Baseband and RIL informations control.
  */
 module.exports = class BasebandRIL extends OverlayPlugin {
+    static get name() {
+        return 'BasebandRIL';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Battery.js
+++ b/src/plugins/Battery.js
@@ -7,6 +7,9 @@ const OverlayPlugin = require('./util/OverlayPlugin');
  * Provides battery level and state control.
  */
 module.exports = class Battery extends OverlayPlugin {
+    static get name() {
+        return 'Battery';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Camera.js
+++ b/src/plugins/Camera.js
@@ -11,6 +11,9 @@ log.setDefaultLevel('debug');
  * Provides client webcam and camera control.
  */
 module.exports = class Camera extends OverlayPlugin {
+    static get name() {
+        return 'Camera';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Clipboard.js
+++ b/src/plugins/Clipboard.js
@@ -10,6 +10,9 @@ log.setDefaultLevel('debug');
  * Provides clipboard data exchange capability between client and instance.
  */
 module.exports = class Clipboard extends OverlayPlugin {
+    static get name() {
+        return 'Clipboard';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/FileUpload.js
+++ b/src/plugins/FileUpload.js
@@ -13,6 +13,9 @@ const QUART = Math.PI / 2;
  * Provides file upload support and Open GApps installation control.
  */
 module.exports = class FileUpload extends OverlayPlugin {
+    static get name() {
+        return 'FileUpload';
+    }
     /**
      * Plugin initialization.
      *
@@ -137,7 +140,7 @@ module.exports = class FileUpload extends OverlayPlugin {
 
         // Generate title
         this.title = document.createElement('div');
-        this.title.className = 'gm-upload-title';
+        this.title.className = 'gm-title';
         this.container.appendChild(this.title);
 
         // Generate input rows

--- a/src/plugins/FingerPrint.js
+++ b/src/plugins/FingerPrint.js
@@ -35,6 +35,9 @@ const FINGERPRINT_MESSAGES = {
     },
 };
 module.exports = class FingerPrint extends OverlayPlugin {
+    static get name() {
+        return 'FingerPrint';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Fullscreen.js
+++ b/src/plugins/Fullscreen.js
@@ -5,6 +5,9 @@
  * Gives the ability to display the renderer on the whole screen.
  */
 module.exports = class Fullscreen {
+    static get name() {
+        return 'Fullscreen';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/GPS.js
+++ b/src/plugins/GPS.js
@@ -12,6 +12,9 @@ log.setDefaultLevel('debug');
  * Provides GPS control.
  */
 module.exports = class GPS extends OverlayPlugin {
+    static get name() {
+        return 'GPS';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Gamepad.js
+++ b/src/plugins/Gamepad.js
@@ -9,6 +9,9 @@ const OverlayPlugin = require('./util/OverlayPlugin');
  * Instance gamepad plugin.
  */
 module.exports = class Gamepad extends OverlayPlugin {
+    static get name() {
+        return 'Gamepad';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/IOThrottling.js
+++ b/src/plugins/IOThrottling.js
@@ -11,6 +11,9 @@ const BYTES_PER_MEGABYTE = BYTES_PER_KILOBYTE << 10;
  * Provides disk I/O control.
  */
 module.exports = class IOThrottling extends OverlayPlugin {
+    static get name() {
+        return 'IOThrottling';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Identifiers.js
+++ b/src/plugins/Identifiers.js
@@ -10,6 +10,9 @@ const DIGITS = '0123456789';
  * Provides device ID (IMEI) and Android ID control.
  */
 module.exports = class Identifiers extends OverlayPlugin {
+    static get name() {
+        return 'Identifiers';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/KeyboardEvents.js
+++ b/src/plugins/KeyboardEvents.js
@@ -43,6 +43,10 @@ const CTRL_SHORTCUT_KEYS = {
  * Translate and forward keyboard events to instance.
  */
 module.exports = class KeyboardEvents {
+    static get name() {
+        return 'KeyboardEvents';
+    }
+
     /**
      * Plugin initialization.
      *

--- a/src/plugins/KeyboardMapping.js
+++ b/src/plugins/KeyboardMapping.js
@@ -97,6 +97,9 @@ const {generateUID} = require('../utils/helpers');
  */
 
 module.exports = class KeyboardMapping {
+    static get name() {
+        return 'KeyboardMapping';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/MouseEvents.js
+++ b/src/plugins/MouseEvents.js
@@ -5,6 +5,10 @@
  * Forward touch events to instance.
  */
 module.exports = class MouseEvents {
+    static get name() {
+        return 'MouseEvents';
+    }
+
     /**
      * Plugin initialization.
      *

--- a/src/plugins/MultiTouchEvents.js
+++ b/src/plugins/MultiTouchEvents.js
@@ -5,6 +5,9 @@
  * Forward multi touch events to instance.
  */
 module.exports = class MultiTouchEvents {
+    static get name() {
+        return 'MultiTouchEvents';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Network.js
+++ b/src/plugins/Network.js
@@ -14,6 +14,9 @@ const MOBILE_SIGNAL_STRENGTH = require('./util/mobile-signal-strength');
  * Provides network I/O control.
  */
 module.exports = class Network extends OverlayPlugin {
+    static get name() {
+        return 'Network';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Phone.js
+++ b/src/plugins/Phone.js
@@ -7,6 +7,9 @@ const OverlayPlugin = require('./util/OverlayPlugin');
  * Provides phone call and SMS support.
  */
 module.exports = class Phone extends OverlayPlugin {
+    static get name() {
+        return 'Phone';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/Screencast.js
+++ b/src/plugins/Screencast.js
@@ -13,6 +13,9 @@ const CAPTURE_INTERVAL_MS = 50;
  * Provides screenshot and video capture.
  */
 module.exports = class Screencast extends OverlayPlugin {
+    static get name() {
+        return 'Screencast';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/StreamBitrate.js
+++ b/src/plugins/StreamBitrate.js
@@ -5,6 +5,9 @@
  * Provides video stream quality (audio and video bitrates) control.
  */
 module.exports = class StreamBitrate {
+    static get name() {
+        return 'StreamBitrate';
+    }
     /**
      * Plugin initialization.
      *

--- a/src/plugins/StreamResolution.js
+++ b/src/plugins/StreamResolution.js
@@ -14,6 +14,9 @@ const RESOLUTIONS = [
  * Provides video stream resolution control.
  */
 module.exports = class StreamResolution {
+    static get name() {
+        return 'StreamResolution';
+    }
     /**
      * Plugin initialization.
      *


### PR DESCRIPTION
## Description

adding static get name() to plugins class, in order to be able to use this.constructor.name in third app which uglify this script


## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
