### PR TITLE
Closing & reopening the webrtc connection loses the mouse & keyboard inputs

### DIFF
--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -247,6 +247,8 @@ module.exports = class DeviceRenderer {
 
         this.webRTCWebsocket.onclose = (event) => {
             store.dispatch({type: 'WEBRTC_CONNECTION_READY', payload: false});
+            store.dispatch({type: 'KEYBOARD_EVENTS_ENABLED', payload: false});
+            store.dispatch({type: 'MOUSE_EVENTS_ENABLED', payload: false});
             video.style.background = this.videoBackupStyleBackground;
             this.initialized = false;
             log.debug('Error! Maybe your VM is not available yet? (' + event.code + ') ' + event.reason);
@@ -477,6 +479,9 @@ module.exports = class DeviceRenderer {
             if (this.gamepadEventsEnabled) {
                 this.gamepadManager.addGamepadCallbacks();
             }
+
+            this.store.dispatch({type: 'KEYBOARD_EVENTS_ENABLED', payload: true});
+            this.store.dispatch({type: 'MOUSE_EVENTS_ENABLED', payload: true});
 
             const playWithSound = this.video.play(); // needed on Safari (web & iOs)
             if (!playWithSound) {


### PR DESCRIPTION
## Description

Since the rework of v4 a bug was present where if you closed & reopened the WebRTC WebSocket you'd lose the inputs from both mouse & keyboard.

After some tests it appears that unregistering the mouse & keyboard events in the store on WebSocket disconnection & then re-registering them when creating the peer connection (as for the touch & gamepad events) fixes this issue.

This PR is the aforementioned fix.

Sorry but as it's quite a technical issue, it's hard to provide a simple screen-record so you'll have to trust me on this 😬 

Fixes #(no related issue)

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
-   [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
-   [x] I have made corresponding changes to the documentation (README.md).
-   [x] I've checked my modifications for any breaking changes.
