### PR TITLE
Always translate home into meta+enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,14 +598,6 @@ Enables or disables the phone widget. This widget can be used to send SMS or pho
 -   **Details:**
     Enable or disable fingerprints widget. This widget can be used to manage fingerprint reading requests. Available for Android 9 and above
 
-### `translateHomeKey`
-
--   **Type:** `Boolean`
--   **Default:** `false`
--   **Compatibility:** `PaaS`
--   **Details:**
-    Translate home key to `META` + `ENTER`
-
 ### `connectionFailedURL`
 
 -   **Type:** `String`

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,6 @@ interface RendererSetupOptions {
     template?: Template; // Default: 'renderer'
     token?: string;
     touch?: boolean; // Default: true
-    translateHomeKey?: boolean; // Default: false
     turn?: {
         urls?: string[];
         username?: string;

--- a/src/DeviceRenderer.js
+++ b/src/DeviceRenderer.js
@@ -124,7 +124,7 @@ module.exports = class DeviceRenderer {
             {
                 enabled: this.options.buttons,
                 class: ButtonsEvents,
-                params: [this.options.i18n, this.options.translateHomeKey],
+                params: [this.options.i18n],
             },
         ];
 

--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -43,7 +43,6 @@ const defaultOptions = {
     diskIO: true,
     gamepad: true,
     biometrics: true,
-    translateHomeKey: false,
     token: '',
     i18n: {},
     stun: {
@@ -108,7 +107,6 @@ module.exports = class DeviceRendererFactory {
      * @param  {boolean}            options.streamResolution       Stream resolution control support activated. Default: true.
      * @param  {boolean}            options.diskIO                 Disk I/O throttling support activated. Default: true.
      * @param  {boolean}            options.gamepad                Experimental gamepad support activated. Default: false.
-     * @param  {boolean}            options.translateHomeKey       Whether or not the HOME key button should be decompose to META + ENTER. Default: false.
      * @param  {string}             options.token                  Instance access token (JWT). Default: ''.
      * @param  {Object}             options.i18n                   Translations keys for the UI. Default: {}.
      * @param  {Object}             options.stun                   WebRTC STUN servers configuration.

--- a/src/plugins/ButtonsEvents.js
+++ b/src/plugins/ButtonsEvents.js
@@ -5,7 +5,7 @@ const ENTER_KEYCODE = '0x01000005';
 const VOLUME_DOWN_KEYCODE = '0x01000070';
 const VOLUME_UP_KEYCODE = '0x01000072';
 const RECENT_APP_KEYCODE = '0x010000be';
-const HOME_KEYCODE = '0x01000010';
+const HOMEPAGE_KEYCODE = '0x01000090';
 const BACK_KEYCODE = '0x01000061';
 const POWER_KEYCODE = '0x0100010b';
 const ROTATE_KEYCODE = 'gm-rotation';
@@ -20,12 +20,10 @@ module.exports = class ButtonsEvents {
      *
      * @param {Object} instance         Associated instance.
      * @param {Object} i18n             Translations keys for the UI.
-     * @param {Object} translateHomeKey Translate HOME key press for the instance.
      */
-    constructor(instance, i18n, translateHomeKey) {
+    constructor(instance, i18n) {
         // Reference instance
         this.instance = instance;
-        this.translateHomeKey = translateHomeKey;
 
         // Register plugin
         this.instance.buttonsEvents = this;
@@ -51,7 +49,7 @@ module.exports = class ButtonsEvents {
                 i18n.BUTTONS_RECENT_APPS || 'Recent applications',
                 true,
             );
-            this.renderToolbarButton(HOME_KEYCODE, 'gm-home', i18n.BUTTONS_HOME || 'Home', true);
+            this.renderToolbarButton(HOMEPAGE_KEYCODE, 'gm-home', i18n.BUTTONS_HOME || 'Home', true);
             this.renderToolbarButton(BACK_KEYCODE, 'gm-back', i18n.BUTTONS_BACK || 'Back', true);
         }
 
@@ -103,8 +101,12 @@ module.exports = class ButtonsEvents {
             return;
         }
 
-        if (id === HOME_KEYCODE && this.translateHomeKey) {
-            // home is meta + enter
+        if (id === HOMEPAGE_KEYCODE) {
+            /**
+             * Translate homepage into meta + enter
+             * Note we could send the homepage keycode directly, see https://source.android.com/docs/core/interaction/input/keyboard-devices#hid-keyboard-and-keypad-page-0x07
+             * but geny's webrtcd doesn't know how to map it yet.
+             */
             this.keyPressEvent(parseInt(META_KEYCODE), '');
             this.keyPressEvent(parseInt(ENTER_KEYCODE), '');
         } else if (id.substring(0, 2) === '0x') {
@@ -126,8 +128,8 @@ module.exports = class ButtonsEvents {
             return;
         }
 
-        if (id === HOME_KEYCODE && this.translateHomeKey) {
-            // "home" is "meta + enter" on PaaS, "move_home" on SaaS
+        if (id === HOMEPAGE_KEYCODE) {
+            // Translate homepage into meta + enter
             this.keyReleaseEvent(parseInt(ENTER_KEYCODE), '');
             this.keyReleaseEvent(parseInt(META_KEYCODE), '');
         } else if (id === ROTATE_KEYCODE) {

--- a/tests/unit/buttonsevent.test.js
+++ b/tests/unit/buttonsevent.test.js
@@ -174,33 +174,8 @@ describe('ButtonsEvents Plugin', () => {
             });
         });
 
-        test('home - default', () => {
+        test('home', () => {
             const button = document.getElementsByClassName('gm-home')[0];
-
-            button.dispatchEvent(new Event('mousedown'));
-            expect(sendEventSpy).toHaveBeenCalledTimes(1);
-            expect(instance.outgoingMessages[0]).toEqual({
-                type: 'KEYBOARD_PRESS',
-                keycode: parseInt('0x01000010'),
-                keychar: '0\n',
-            });
-
-            button.dispatchEvent(new Event('mouseup'));
-            expect(sendEventSpy).toHaveBeenCalledTimes(2);
-            expect(instance.outgoingMessages[1]).toEqual({
-                type: 'KEYBOARD_RELEASE',
-                keycode: parseInt('0x01000010'),
-                keychar: '0\n',
-            });
-        });
-
-        test('home - translated', () => {
-            instance = new Instance({
-                navbar: true,
-            });
-            new ButtonsEvents(instance, {}, true);
-            const button = document.getElementsByClassName('gm-home')[0];
-            sendEventSpy = jest.spyOn(instance, 'sendEvent');
 
             button.dispatchEvent(new Event('mousedown'));
             expect(sendEventSpy).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Description

**JIRA**: [SYSTEM-2682 ](https://genymobile.atlassian.net/browse/SYSTEM-2682)

Home widget button is broken on ARM SaaS which uses a PaaS image, as desktop & paas images handle the home button differently. 

First, the [Android documentation](https://source.android.com/docs/core/interaction/input/keyboard-devices#hid-keyboard-and-keypad-page-0x07) for the actual mapping between linux keyboard keycodes and Android keycodes tells us:
- Linux `KEY_HOMEPAGE` (`Qt::Key_HomePage`) maps to Android [KEYCODE_HOME](https://developer.android.com/reference/android/view/KeyEvent#KEYCODE_HOME) and is the physical home button (back to "desktop")
- Linux `KEY_HOME` (`Qt::Key_Home`) maps to Android [KEYCODE_MOVE_HOME](https://developer.android.com/reference/android/view/KeyEvent#KEYCODE_MOVE_HOME) and is 
   > "Used for scrolling or moving the cursor around to the start of a line or to the top of a list.

Historically, it seems that the desktop image maps `KEYCODE_MOVE_HOME` to `KEYCODE_HOME`, in `device/genymotion/vbox86/Genymotion_Virtual_Input.kl`, so the SaaS web player mapped the home widget to this button.

Now, the PaaS image does not have this mapping (it is not necessary), so the webplayer has an option to translate this button to Meta+Enter, which is a shortcut for the home button. 

However, this results in the Paas in Saas configuration being broken, as the SaaS web player sends (ultimately, through webrtcd mapping & redis) the `KEYCODE_MOVE_HOME` to the PaaS image.

This fix:
- Removes the option, and always translate home into Meta+Enter as it's always a valid shortcut (tested Android 8-14). 
   - This will require removing the option in web-ui.
- Changes the Keycode associated with the home widget button to `KEY_HOMEPAGE`, as it is more accurate, even though it ends up being translated. We could later remove the translation, when webrtcd is aware of this keycode.

Fixes SYSTEM-2682

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
-   [x] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
-   [x] I have made corresponding changes to the documentation (README.md).
-   [x] I've checked my modifications for any breaking changes.
