### PR TITLE
Update the example to use the latest apis for fetching recipes and accessing instances.

### DIFF
--- a/example/geny-window.html
+++ b/example/geny-window.html
@@ -61,10 +61,9 @@
                 <datalist id="instances-history"></datalist>
                 <div class="note" id="input-note">
                     <ul>
-                        <li><strong>Instance uuid:</strong> the uuid of a launched device.</li>
+                        <li><strong>Instance uuid:</strong> the uuid of a launched device. <strong>(Genymotion SaaS only)</strong></li>
                         <li>
-                            <strong>WebSocket address:</strong> the WebSocket address (starting with "wss://") of a
-                            launched device.
+                            <strong>WebSocket address:</strong> the WebSocket address ("<i>wss://public ip address</i>") of the device. <strong>(Genymotion Device Image only)</strong>
                         </li>
                     </ul>
                 </div>

--- a/example/geny-window.js
+++ b/example/geny-window.js
@@ -146,14 +146,14 @@ const stopInstance = async () => {
 // Fetch recipe and add them to the select
 const fetchRecipes = async () => {
     try {
-        const response = await fetch(baseUrlToFetch + `/v1/recipes?limit=1000`, {
+        const response = await fetch(baseUrlToFetch + `/v3/recipes/?arch=x86_64&arch=x86&arch=arm64&limit=1000`, {
             ...requestInit,
             method: 'GET',
         });
-        const recipes = await response.json();
+        const recipesResult = await response.json();
 
         if (response.status !== 200) {
-            alert(recipes.message);
+            alert(recipesResult.message);
             return;
         }
 
@@ -166,30 +166,20 @@ const fetchRecipes = async () => {
         placeholderOption.disabled = true;
         placeholderOption.selected = true;
         selectElement.add(placeholderOption, selectElement.firstChild);
+        const recipes = recipesResult.results;
 
-        for (const recipeType in recipes) {
-            addOptionsToGroup(recipeType, recipes[recipeType]);
+        for (let i = 0; i < recipes.length; i++) {
+            const recipe = recipes[i];
+            const optionElement = document.createElement('option');
+            optionElement.value = recipe.uuid;
+            optionElement.textContent = recipe.name;
+            selectElement.appendChild(optionElement);
         }
     } catch (error) {
         alert(error);
     }
 };
 
-const addOptionsToGroup = (recipeType, recipes) => {
-    const selectElement = document.querySelector('#listRecipes');
-
-    const optgroup = document.createElement('optgroup');
-    optgroup.label = recipeType;
-
-    recipes.forEach((recipe) => {
-        const optionElement = document.createElement('option');
-        optionElement.value = recipe.uuid;
-        optionElement.textContent = recipe.name;
-        optgroup.appendChild(optionElement);
-    });
-
-    selectElement.appendChild(optgroup);
-};
 
 // connect to an existing instance through an instance Uuid or an instance ws address
 const connectInstance = async (wsAddress) => {

--- a/example/geny-window.js
+++ b/example/geny-window.js
@@ -29,11 +29,14 @@ const getApiToken = async () => {
 };
 
 // get jwt token
-const getJWTToken = async () => {
+const getJWTToken = async (instanceUuid) => {
     try {
         const response = await fetch(baseUrlToFetch + `/v1/instances/access-token`, {
             ...requestInit,
             method: 'POST',
+            body: JSON.stringify({
+              instance_uuid: instanceUuid,
+            }),
         });
 
         if (response.status !== 200) {
@@ -95,7 +98,7 @@ const startInstance = async (recipeUuid) => {
 
     instanceUuid = recipe.uuid;
 
-    await getJWTToken();
+    await getJWTToken(instanceUuid);
 
     return recipe;
 };
@@ -202,7 +205,7 @@ const connectInstance = async (wsAddress) => {
     });
     const instance = await response.json();
     instanceUuid = instance.uuid;
-    await getJWTToken();
+    await getJWTToken(instanceUuid);
     initPlayer(instance.publicWebrtcUrl);
 };
 


### PR DESCRIPTION
## Description

~☝🏻 This is currently based on top of #112. It should be rebased on `main` after #112 is merged.~

### Accessing instances

See the documentation for `POST /v1/instances/access-token`: https://developer.genymotion.com/saas/#tag/Instances-v1/operation/accessToken

It has an `instance_uuid` request payload field.


#### Text clarification

Now that an instance uuid is required to connect to a SaaS instance, clarify that:
* Connection via instance uuid is only for Genymotion SaaS.
* Connection via webrtc address is only for Genymotion Device Image.

#### Tests

Tested accessing a device:
|Platform|By launching from the example|By connecting to already launched device|
|---|---|---|
|SaaS|![image](https://github.com/user-attachments/assets/337d8371-053d-494e-89af-c555917463d0)|![image](https://github.com/user-attachments/assets/ab2aa2ad-d195-4c76-978f-b5569bc95b0b)|
|Device Image| N/A | Help 😅 |



### Fetching recipes

Use the `GET /v3/recipes/` route to retrieve recipes.
    
See the documentation: https://developer.genymotion.com/saas/#tag/Recipes-v3/operation/listRecipesV3


#### Tests
Note that the v3 recipes route returns recipes in a flat list.

|Before|After|
|---|---|
|![Screenshot from 2024-09-26 14-55-44](https://github.com/user-attachments/assets/3ea46c78-e810-4dc3-b4ef-6c60e6dbaa6f)|![image](https://github.com/user-attachments/assets/05952944-6644-4ab4-8432-0be0d9271b56)|


## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
-   [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
    - Only tested on Edge :)
-   [ ] I have made corresponding changes to the documentation (README.md).
    - Don't think it's needed?
-   [ ] I've checked my modifications for any breaking changes.
    - Not sure what can break, it's an example.
