### PR TITLE
Fix the example: remove api token error when we fetch recipes

### DIFF
--- a/example/geny-window.js
+++ b/example/geny-window.js
@@ -155,6 +155,8 @@ const fetchRecipes = async () => {
         }
 
         const selectElement = document.querySelector('#listRecipes');
+        // Empty the select before adding new options.
+        selectElement.innerHTML = '';
         const placeholderOption = document.createElement('option');
         placeholderOption.textContent = 'Select a recipe';
         placeholderOption.value = '';


### PR DESCRIPTION
## Description

This fixes a minor bug where we had an error message in the recipe selection list.

Steps to reproduce:
* open the example page
* copy your api token
* expected behavior: the recipes list is populated
* actual behavior: the recipes list is populated BUT there's still an error about a missing api token

Before:
![image](https://github.com/user-attachments/assets/2a8b6c3e-9179-470c-b654-d16656a0953f)

With the fix:
![image](https://github.com/user-attachments/assets/d239204a-1f87-455c-af04-ca2a85d4be10)


## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [x] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
-   [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
    - Not really, it's "just" an example 🤞🏻 😅 
-   [ ] I have made corresponding changes to the documentation (README.md).
    - I don't think anything is needed.
-   [ ] I've checked my modifications for any breaking changes.
    - Not really, it's "just" an example 🤞🏻 😅 
