### PR TITLE
[PLAYER-71] widget scrollable when widow size lower than widget

### DIFF
--- a/src/plugins/Clipboard.js
+++ b/src/plugins/Clipboard.js
@@ -80,11 +80,12 @@ module.exports = class Clipboard extends OverlayPlugin {
             title: this.i18n.CLIPBOARD_TITLE || 'Device Clipboard',
             classes: 'gm-clipboard-plugin',
             width: 378,
-            height: 495,
+            height: 484,
         });
         this.container = container;
 
         const text = document.createElement('div');
+        text.className = 'gm-clipboard-text';
         text.innerHTML =
             this.i18n.CLIPBOARD_TEXT ||
             // eslint-disable-next-line max-len

--- a/src/plugins/Network.js
+++ b/src/plugins/Network.js
@@ -176,7 +176,7 @@ module.exports = class Network extends OverlayPlugin {
         const {container} = this.createTemplateModal({
             title: this.i18n.NETWORK_TITLE || 'Network',
             width: 378,
-            height: 550,
+            height: 610,
             classes: 'gm-network-plugin',
         });
 

--- a/src/plugins/Phone.js
+++ b/src/plugins/Phone.js
@@ -53,7 +53,7 @@ module.exports = class Phone extends OverlayPlugin {
             title: this.i18n.PHONE_TITLE || 'Phone',
             classes: 'gm-phone-plugin',
             width: 378,
-            height: 617,
+            height: 642,
         });
 
         // Generate input rows

--- a/src/scss/components/_clipboard.scss
+++ b/src/scss/components/_clipboard.scss
@@ -16,8 +16,14 @@
             }
         }
 
+        &-clipboard-text {
+            margin: $spacing-s 0;
+        }
+
         &-clipboard-input {
-            margin: $spacing-m 0;
+            margin-top: $spacing-s;
+            margin-bottom: $spacing-s;
+            flex: 1;
         }
         &-actions {
             display: flex;

--- a/src/scss/components/_network.scss
+++ b/src/scss/components/_network.scss
@@ -5,17 +5,18 @@
     .gm-network-wifi-section {
         display: flex;
         justify-content: space-between;
-        margin-bottom: $spacing-m;
+        margin-bottom: $spacing-s * 2;
+        margin-top: $spacing-s;
     }
     .gm-mobile-data-switch {
         display: flex;
         justify-content: space-between;
-        margin-top: $spacing-m;
-        margin-bottom: $spacing-m * 2;
+        margin-top: $spacing-l;
+        margin-bottom: $spacing-s * 2;
     }
 
     .gm-network-type-dropdown {
-        margin-bottom: $spacing-m * 2;
+        margin-bottom: $spacing-xl;
         .dropdown-menu {
             .dropdown-item {
                 display: flex;
@@ -66,7 +67,7 @@
 
     .gm-network-mobile-section {
         .gm-signal-strength-dropdown {
-            margin-bottom: $spacing-m * 2;
+            margin-bottom: $spacing-xl;
         }
         &.disabled {
             label,

--- a/src/scss/components/_phone.scss
+++ b/src/scss/components/_phone.scss
@@ -5,7 +5,7 @@
     .gm-phone-group {
         display: flex;
         flex-direction: column;
-        margin-bottom: $spacing-l;
+        margin-bottom: $spacing-m;
         .gm-phone-call,
         .gm-phone-send {
             align-self: flex-end;

--- a/src/scss/components/_widgetwindow.scss
+++ b/src/scss/components/_widgetwindow.scss
@@ -142,6 +142,10 @@
     flex-direction: column;
     padding-bottom: $modal-y-padding;
     z-index: 100;
+
+    // handle overflow when the modal is too high
+    overflow-y: auto;
+    max-height: 100%;
     &.gm-visible {
         opacity: 1;
         transition:
@@ -176,6 +180,11 @@
         font-size: 16px;
         font-weight: bold;
         letter-spacing: 0.1em;
+        // If the widget height is higher than the viewport height, the modal is scrollable but the header will be sticky
+        background: var(--gm-secondary-color);
+        position: sticky;
+        top: 0;
+        z-index: 200;
         // Disable text selection, in order to avoid to select the text when dragging the modal
         user-select: none;
 


### PR DESCRIPTION
## Description

make widgets scrollable when window size is smaller than widget. When window size is saller than the widget, the header of the widget is fix and the body of the widget is scrollable

![image](https://github.com/user-attachments/assets/7ed9ba34-40e7-4700-afdf-524723f006d6)


## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

-   [ ] I've read & comply with the [contributing guidelines](https://github.com/Genymobile/genymotion-device-web-player/blob/main/CONTRIBUTING.md)
-   [ ] I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
-   [ ] I have made corresponding changes to the documentation (README.md).
-   [ ] I've checked my modifications for any breaking changes.
