### PR TITLE
[PLAYER-97] hide toolbar if no icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ A device renderer instance can be configured using the `options` argument (objec
 - **Type:** `Boolean`
 - **Default:** `true`
 - **Details:**
-  When enabled, plugin controls (e.g. rotate, fullscreen, record, etc...) are displayed in a floating toolbar below the virtual device display.
+  When enabled, plugin controls (e.g. rotate, fullscreen, record, etc...) are displayed in a floating toolbar below the virtual device display, the toolbar is visible only if it contains at least one item.
 
 #### `connectionFailedURL`
 
@@ -609,6 +609,14 @@ A device renderer instance can be configured using the `options` argument (objec
 - **Compatibility:** `PaaS`, `SaaS`
 - **Details:**
   Enable or disable the diskIO widget. This widget can be used to modify Disk IO (throttling) of the Android virtual device.
+
+#### displayToolbar
+
+- **Type:** `Boolean`
+- **Default:** `true`
+- **Compatibility:** `PaaS`, `SaaS`
+- **Details:**
+  Enable or disable the side toolbar visibility. If set to `true`, the toolbar is visible only if it contains at least one item.
 
 #### fileUpload <img align="right" src="./doc/assets/ic_installation.svg">
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,7 @@ interface RendererSetupOptions {
     clipboard?: boolean; // Default: true
     connectionFailedURL?: string;
     diskIO?: boolean; // Default: true
+    displayToolbar?: boolean; // Default: true
     fileUpload?: boolean; // Default: true
     gappsInstall?: boolean; // Default: true
     fileUploadUrl?: string;

--- a/src/DeviceRendererFactory.js
+++ b/src/DeviceRendererFactory.js
@@ -26,6 +26,7 @@ const defaultOptions = {
         'ButtonsEvents_POWER',
     ],
     toolbarPosition: 'right',
+    displayToolbar: true,
     floatingToolbar: true,
     touch: true,
     mouse: true,
@@ -88,6 +89,7 @@ export default class DeviceRendererFactory {
      * @param  {Object}             options                        Various configuration options.
      * @param  {boolean}            options.showPhoneBorder        Show phone border. Default: false.
      * @param  {string}             options.toolbarPosition        Toolbar position. Default: 'right'. Available values: 'left', 'right'.
+     * @param  {boolean}            options.displayToolbar         Show toolbar. Default: true.
      * @param  {boolean}            options.toolbarOrder           Toolbar buttons order. Default: see defaultOptions.
      * @param  {boolean}            options.touch                  Touch support activated. Default: true.
      * @param  {boolean}            options.mouse                  Mouse support activated. Default: true.
@@ -184,7 +186,6 @@ export default class DeviceRendererFactory {
     loadTemplate(dom, options) {
         dom.innerHTML = `
         <div class="gm-wrapper waitingForStream ${options.showPhoneBorder ? 'phoneBorder' : ''} 
-        ${options.floatingToolbar ? 'floatingBarDisplayed' : ''}
         toolbarPosition-${options.toolbarPosition}">
             <div class="player-screen-wrapper">
                 <div class="gm-video-wrapper">
@@ -195,14 +196,12 @@ export default class DeviceRendererFactory {
                             : ''
                     }
                 </div>
-                ${
-                    options.floatingToolbar
-                        ? // eslint-disable-next-line max-len
-                          '<div class="gm-floating-toolbar-wrapper"><div class="gm-floating-toolbar"><ul></ul></div></div>'
-                        : ''
-                }
+                <div class="gm-floating-toolbar-wrapper 
+                    ${!options.floatingToolbar ? 'hidden' : 'floatingBarDisplayed'}">
+                    <div class="gm-floating-toolbar"><ul></ul></div>
+                </div>
             </div>
-            <div class="gm-toolbar-wrapper">
+            <div class="gm-toolbar-wrapper" ${!options.floatingToolbar ? 'hidden' : ''}>
                 <div class="gm-toolbar">
                     <ul></ul>
                 </div>
@@ -308,11 +307,8 @@ export default class DeviceRendererFactory {
         if (floatingToolbar) {
             const floatingToolbarOrder = [
                 'ButtonsEvents_ROTATE',
-                'separator',
                 'Screenshot',
-                'separator',
                 'Screenrecord',
-                'separator',
                 'Fullscreen',
             ];
 
@@ -321,11 +317,8 @@ export default class DeviceRendererFactory {
             sortedToolbarItems.length = 0;
             sortedToolbarItems.push(...filteredToolbarItems);
             floatingToolbarOrder.forEach((name) => {
-                if (name === 'separator') {
-                    instance.toolbarManager.renderSeparator(true);
-                } else {
-                    instance.toolbarManager.renderButton(name, true);
-                }
+                // For floatingBar, separators are automatically added after each button, so we don't need to handle them here
+                instance.toolbarManager.renderButton(name, true);
             });
         }
         sortedToolbarItems.forEach(({key, value}) => {
@@ -335,5 +328,9 @@ export default class DeviceRendererFactory {
                 instance.toolbarManager.renderButton(key);
             }
         });
+
+        // Hide toolbars if requested or empty
+        const {displayToolbar} = instance.options;
+        instance.toolbarManager.updateToolbarVisibility(displayToolbar, floatingToolbar);
     }
 }

--- a/src/plugins/util/ToolBarManager.js
+++ b/src/plugins/util/ToolBarManager.js
@@ -6,8 +6,15 @@ export default class ToolbarManager {
      */
     constructor(instance) {
         this.instance = instance;
-        this.toolbar = document.querySelector('.gm-toolbar ul');
-        this.floatingToolbar = document.querySelector('.gm-floating-toolbar ul');
+        this.toolbarWrapper = document.querySelector('.gm-toolbar-wrapper');
+        if (this.toolbarWrapper) {
+            this.toolbar = this.toolbarWrapper.querySelector('.gm-toolbar ul');
+        }
+
+        this.floatingToolbarWrapper = document.querySelector('.gm-floating-toolbar-wrapper');
+        if (this.floatingToolbarWrapper) {
+            this.floatingToolbar = this.floatingToolbarWrapper.querySelector('.gm-floating-toolbar ul');
+        }
 
         if (!this.toolbar) {
             log.error('Toolbar container not found.');
@@ -103,6 +110,7 @@ export default class ToolbarManager {
         // Adding HTML element to the DOM
         if (isInfloatingBar) {
             this.floatingToolbar.appendChild(button);
+            this.renderSeparator(true);
         } else {
             this.toolbar.appendChild(button);
         }
@@ -284,6 +292,48 @@ export default class ToolbarManager {
      */
     getButtonById(id) {
         return this.buttonRegistry.get(id);
+    }
+
+    /**
+     * Get the number of buttons in the toolbar (excluding separators).
+     * @param {boolean} isInfloatingBar - Whether to check the floating toolbar.
+     * @returns {number} The number of buttons.
+     */
+    getButtonCount(isInfloatingBar = false) {
+        let count = 0;
+        for (const buttonData of this.buttonRegistry.values()) {
+            if (buttonData.isInfloatingBar === isInfloatingBar) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Update visibility of toolbars based on configuration and content.
+     * @param {boolean} displayToolbar - Whether the main toolbar should be displayed.
+     * @param {boolean} displayFloatingToolbar - Whether the floating toolbar should be displayed.
+     */
+    updateToolbarVisibility(displayToolbar, displayFloatingToolbar) {
+        if (this.toolbarWrapper) {
+            const count = this.getButtonCount(false);
+            if (!displayToolbar || count === 0) {
+                this.toolbarWrapper.classList.add('hidden');
+            } else {
+                this.toolbarWrapper.classList.remove('hidden');
+            }
+        }
+
+        if (this.floatingToolbarWrapper) {
+            const count = this.getButtonCount(true);
+            if (!displayFloatingToolbar || count === 0) {
+                this.floatingToolbarWrapper.classList.add('hidden');
+                this.floatingToolbarWrapper.classList.remove('floatingBarDisplayed');
+            } else {
+                this.floatingToolbarWrapper.classList.remove('hidden');
+                this.floatingToolbarWrapper.classList.add('floatingBarDisplayed');
+            }
+        }
     }
 
     /**

--- a/src/scss/base/_genymotion.scss
+++ b/src/scss/base/_genymotion.scss
@@ -383,18 +383,16 @@
             }
         }
 
-        &:not(.floatingBarDisplayed) {
-            .player-screen-wrapper {
-                padding-bottom: 25px;
-            }
-        }
-
         .player-screen-wrapper {
             display: flex;
             flex-direction: column;
             justify-content: space-between;
             flex: 1;
             padding-top: 25px;
+
+            &:not(:has(.floatingBarDisplayed)) {
+                padding-bottom: 25px;
+            }
 
             .gm-video-wrapper {
                 display: flex;

--- a/src/scss/components/_toolbar.scss
+++ b/src/scss/components/_toolbar.scss
@@ -53,6 +53,9 @@
                             margin-right: 0;
                             margin-top: auto;
                             margin-bottom: auto;
+                            &:last-child {
+                                display: none;
+                            }
                         }
 
                         .gm-screenrecord-button {
@@ -107,6 +110,10 @@
                         height: 1px;
                         margin-left: auto;
                         margin-right: auto;
+                        &+.gm-separator {
+                            // Don't display consecutive separators
+                            display: none;
+                        }
                     }
 
                     &:not(.gm-separator):hover {

--- a/tests/unit/floatingToolBar.test.js
+++ b/tests/unit/floatingToolBar.test.js
@@ -1,20 +1,102 @@
 import Instance from '../mocks/DeviceRenderer.js';
 
-describe('Floating Toolbar', () => {
-    describe('when floatingToolbar is true', () => {
-        test('should display floating toolbar', () => {
-            new Instance({floatingToolbar: true});
-            const floatingToolbar = document.querySelector('.gm-floating-toolbar-wrapper');
-            expect(floatingToolbar).not.toBeNull();
-            expect(floatingToolbar.style.display).not.toBe('none');
+describe('Toolbar Visibility', () => {
+    describe('Floating Toolbar', () => {
+        afterEach(() => {
+            document.body.innerHTML = '';
+        });
+
+        test('should be hidden if toolbar is empty', () => {
+            const instance = new Instance({floatingToolbar: true});
+            const floatingToolbarWrapper = document.querySelector('.gm-floating-toolbar-wrapper');
+            const toolbarWrapper = document.querySelector('.gm-toolbar-wrapper');
+
+            // Check existence
+            expect(floatingToolbarWrapper).not.toBeNull();
+
+            // Simulate visibility update
+            instance.toolbarManager.updateToolbarVisibility(
+                instance.options.displayToolbar, instance.options.floatingToolbar);
+
+            // Should be hidden because empty
+            expect(floatingToolbarWrapper.classList.contains('hidden')).toBe(true);
+            expect(toolbarWrapper.classList.contains('hidden')).toBe(true);
+        });
+
+        test('should be visible when buttons are added', () => {
+            const instance = new Instance({floatingToolbar: true});
+            const floatingToolbarWrapper = document.querySelector('.gm-floating-toolbar-wrapper');
+
+            // Add a button to floating toolbar
+            instance.toolbarManager.registerButton({
+                id: 'test-btn',
+                iconClass: 'test-icon'
+            });
+            instance.toolbarManager.renderButton('test-btn', true);
+
+            // Update visibility
+            instance.toolbarManager.updateToolbarVisibility(
+                instance.options.displayToolbar, instance.options.floatingToolbar);
+
+            // Should be visible
+            expect(floatingToolbarWrapper.classList.contains('hidden')).toBe(false);
+        });
+
+        test('should not exist when floatingToolbar option is false', () => {
+            new Instance({floatingToolbar: false});
+            const floatingToolbarWrapper = document.querySelector('.gm-floating-toolbar-wrapper');
+            expect(floatingToolbarWrapper.classList.contains('hidden')).toBe(true);
         });
     });
 
-    describe('when floatingToolbar is false', () => {
-        test('should not display floating toolbar', () => {
-            new Instance({floatingToolbar: false});
-            const floatingToolbar = document.querySelector('.gm-floating-toolbar-wrapper');
-            expect(floatingToolbar).toBeNull();
+    describe('Main Toolbar', () => {
+        afterEach(() => {
+            document.body.innerHTML = '';
+        });
+
+        test('should be hidden by default (empty)', () => {
+            const instance = new Instance({displayToolbar: true});
+            const toolbarWrapper = document.querySelector('.gm-toolbar-wrapper');
+
+            expect(toolbarWrapper).not.toBeNull();
+
+            instance.toolbarManager.updateToolbarVisibility(
+                instance.options.displayToolbar, instance.options.floatingToolbar);
+
+            expect(toolbarWrapper.classList.contains('hidden')).toBe(true);
+        });
+
+        test('should be visible when buttons are added', () => {
+            const instance = new Instance({displayToolbar: true});
+            const toolbarWrapper = document.querySelector('.gm-toolbar-wrapper');
+
+            instance.toolbarManager.registerButton({
+                id: 'main-btn',
+                iconClass: 'test-icon'
+            });
+            instance.toolbarManager.renderButton('main-btn', false);
+
+            instance.toolbarManager.updateToolbarVisibility(
+                instance.options.displayToolbar, instance.options.floatingToolbar);
+
+            expect(toolbarWrapper.classList.contains('hidden')).toBe(false);
+        });
+
+        test('should be hidden when displayToolbar is false', () => {
+            const instance = new Instance({displayToolbar: false});
+            const toolbarWrapper = document.querySelector('.gm-toolbar-wrapper');
+
+            // Add button to ensure it's hidden even if not empty
+            instance.toolbarManager.registerButton({
+                id: 'main-btn',
+                iconClass: 'test-icon'
+            });
+            instance.toolbarManager.renderButton('main-btn', false);
+
+            instance.toolbarManager.updateToolbarVisibility(
+                instance.options.displayToolbar, instance.options.floatingToolbar);
+
+            expect(toolbarWrapper.classList.contains('hidden')).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Description

This PR changes the behavior of toolbars:

- An option has been added to display or hide the toolbar.

- If a toolbar (floating or legacy) has no elements, it is hidden (even if the "show" option is set to true).